### PR TITLE
dev: add package type to composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
   "name": "wpengine/wp-graphql-content-blocks",
   "description": "Plugin that extends WPGraphQL to support querying (Gutenberg) Blocks as data.",
-  "type": "project",
+  "type": "wordpress-plugin",
   "prefer-stable": true,
   "minimum-stability": "dev",
   "require-dev": {


### PR DESCRIPTION
This PR sets the Composer package type to "wordpress-plugin", so dependents can autoinstall the plugin in `wp-content/plugins` directory using the `extra.installer-paths` property.