### PR TITLE
dev: filter content before parse_blocks()

### DIFF
--- a/includes/Data/ContentBlocksResolver.php
+++ b/includes/Data/ContentBlocksResolver.php
@@ -14,7 +14,7 @@ final class ContentBlocksResolver {
 	 * Retrieves a list of content blocks
 	 *
 	 * @param mixed $node The node we are resolving.
-	 * @param array $args Query args to pass to the connection resolver.
+	 * @param array $args GraphQL query args to pass to the connection resolver.
 	 */
 	public static function resolve_content_blocks( $node, $args ) {
 		$content = null;
@@ -30,6 +30,15 @@ final class ContentBlocksResolver {
 			$post    = get_post( $node->databaseId );
 			$content = $post->post_content;
 		}
+
+		/**
+		 * Filters the content retrieved from the node used to parse the blocks.
+		 *
+		 * @param string                 $content The content to parse.
+		 * @param \WPGraphQL\Model\Model $node    The node we are resolving.
+		 * @param array                  $args    GraphQL query args to pass to the connection resolver.
+		 */
+		$content = apply_filters( 'wpgraphql_content_blocks_resolver_content', $content, $node, $args );
 
 		if ( empty( $content ) ) {
 			return array();


### PR DESCRIPTION
This PR adds the `wpgraphql_content_blocks_resolver_content` filter to allow users to set the `$content` passed to `parse_blocks()` in `ContentBlocksResolver::resolve_content_blocks()`.

This filter is useful for adding block support via `NodeWithContentBlocks` on objects that dont use the built-in `Post` model.

### Example

```php
/**
 * Gets the content from the model for parsing by WPGraphQL ContentBlocks.
 *
 * @param string $content The content to parse.
 * @param \WPGraphQL\Model\Model $model The model to get content from.
 */
public static function get_content_from_model( $content, $model ) {
  if ( $model instanceof TemplatePart ) {
    $content = $model->content ?: '';
  }

  return $content;
}
```  

![image](https://user-images.githubusercontent.com/29322304/220308265-1cc27192-7344-4731-a474-a40e9f609703.png)