### PR TITLE
Chore: Remove Extra Block `style` fields

### DIFF
--- a/includes/Blocks/CoreCode.php
+++ b/includes/Blocks/CoreCode.php
@@ -4,12 +4,6 @@ namespace WPGraphQL\ContentBlocks\Blocks;
 class CoreCode extends Block {
 
 	protected ?array $additional_block_attributes = array(
-		'style'        => array(
-			'type'      => 'string',
-			'selector'  => 'pre',
-			'source'    => 'attribute',
-			'attribute' => 'style',
-		),
 		'cssClassName' => array(
 			'type'      => 'string',
 			'selector'  => 'pre',

--- a/includes/Blocks/CoreColumn.php
+++ b/includes/Blocks/CoreColumn.php
@@ -10,11 +10,5 @@ class CoreColumn extends Block {
 			'source'    => 'attribute',
 			'attribute' => 'class',
 		),
-		'style'        => array(
-			'type'      => 'string',
-			'selector'  => 'div',
-			'source'    => 'attribute',
-			'attribute' => 'style',
-		),
 	);
 }

--- a/includes/Blocks/CoreImage.php
+++ b/includes/Blocks/CoreImage.php
@@ -5,12 +5,6 @@ namespace WPGraphQL\ContentBlocks\Blocks;
 class CoreImage extends Block {
 
 	protected ?array $additional_block_attributes = array(
-		'style'     => array(
-			'type'      => 'string',
-			'selector'  => 'figure',
-			'source'    => 'attribute',
-			'attribute' => 'style',
-		),
 		'className' => array(
 			'type'      => 'string',
 			'selector'  => 'figure',


### PR DESCRIPTION
This PR removed the erroneous `style` fields added on some blocks as they create issues with WPGraphQL type checking.