### PR TITLE
[Merl 726] - BREAKING! Change `nodeId` -> `clientId` and `parentId` -> `parentClientId`

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,19 +111,19 @@ It will return the following blocks:
 	  "__typename": "CoreColumns",
 		"name": "core/columns",
 		"id": "63dbec9abcf9d",
-		"parentId": null
+		"parentClientId": null
 	},
 	{
 	  "__typename": "CoreColumn",
 	  "name": "core/column",
 	  "id": "63dbec9abcfa6",
-      "parentId": "63dbec9abcf9d"
+      "parentClientId": "63dbec9abcf9d"
 	},
 	{
 	  "__typename": "CoreParagraph",
 	  "name": "core/paragraph",
 	  "id": "63dbec9abcfa9",
-      "parentId": "63dbec9abcfa6",
+      "parentClientId": "63dbec9abcfa6",
 	  "attributes": {
 	    "content": "Example paragraph in Column 1",
 	    "className": null
@@ -134,12 +134,12 @@ It will return the following blocks:
 
 The `CoreColumns` contains one or more `CoreColumn` block, and each `CoreColumn` contains a `CoreParagraph`.
 
-Given the flattened list of blocks though, how can you put it back? Well that's where you use the `nodeId` and `parentId` fields to assign temporary unique ids for each block.
+Given the flattened list of blocks though, how can you put it back? Well that's where you use the `` and `parentId` fields to assign temporary unique ids for each block.
 
-The `nodeId` field assigns a temporary unique id for a specific block and the `parentId` will
-be assigned only if the current block has a parent. If the current block does have a parent, it will get the parent's `nodeId` value.
+The `clientId` field assigns a temporary unique id for a specific block and the `parentClientId` will
+be assigned only if the current block has a parent. If the current block does have a parent, it will get the parent's `clientId` value.
 
 So in order to put everything back in the Headless site, you want to use the `flatListToHierarchical` function as mentioned in the [WPGraphQL docs](https://www.wpgraphql.com/docs/menus#hierarchical-data).
 
 ### Note
-> Currently the `nodeId` field is only unique per request and is not persisted anywhere. If you perform another request each block will be assigned a new `nodeId` each time.
+> Currently the `clientId` field is only unique per request and is not persisted anywhere. If you perform another request each block will be assigned a new `clientId` each time.

--- a/includes/Data/ContentBlocksResolver.php
+++ b/includes/Data/ContentBlocksResolver.php
@@ -93,7 +93,7 @@ final class ContentBlocksResolver {
 		$block['clientId'] = isset( $block['clientId'] ) ? $block['clientId'] : uniqid();
 		array_push( $result, $block );
 		foreach ( $block['innerBlocks'] as $child ) {
-			$child['parentId'] = $block['clientId'];
+			$child['parentClientId'] = $block['clientId'];
 			$result            = array_merge( $result, self::flatten_inner_blocks( $child ) );
 		}
 		return $result;

--- a/includes/Data/ContentBlocksResolver.php
+++ b/includes/Data/ContentBlocksResolver.php
@@ -61,7 +61,7 @@ final class ContentBlocksResolver {
 
 		$parsed_blocks = array_map(
 			function ( $parsed_block ) {
-				$parsed_block['nodeId'] = uniqid();
+				$parsed_block['clientId'] = uniqid();
 				return $parsed_block;
 			},
 			$parsed_blocks
@@ -86,14 +86,14 @@ final class ContentBlocksResolver {
 	}
 
 	/**
-	 * Flattens a block and it's inner blocks into a single while attaching unique nodeId's
+	 * Flattens a block and it's inner blocks into a single while attaching unique clientId's
 	 */
 	private static function flatten_inner_blocks( $block ) {
 		$result          = array();
-		$block['nodeId'] = isset( $block['nodeId'] ) ? $block['nodeId'] : uniqid();
+		$block['clientId'] = isset( $block['clientId'] ) ? $block['clientId'] : uniqid();
 		array_push( $result, $block );
 		foreach ( $block['innerBlocks'] as $child ) {
-			$child['parentId'] = $block['nodeId'];
+			$child['parentId'] = $block['clientId'];
 			$result            = array_merge( $result, self::flatten_inner_blocks( $child ) );
 		}
 		return $result;

--- a/includes/Type/InterfaceType/EditorBlockInterface.php
+++ b/includes/Type/InterfaceType/EditorBlockInterface.php
@@ -74,18 +74,18 @@ final class EditorBlockInterface {
 				'eagerlyLoadType' => true,
 				'description'     => __( 'Blocks that can be edited to create content and layouts', 'wp-graphql-content-blocks' ),
 				'fields'          => array(
-					'nodeId'                  => array(
+					'clientId'                  => array(
 						'type'        => 'String',
 						'description' => __( 'The id of the Block', 'wp-graphql-content-blocks' ),
 						'resolve'     => function ( $block ) {
-							return isset( $block['nodeId'] ) ? $block['nodeId'] : uniqid();
+							return isset( $block['clientId'] ) ? $block['clientId'] : uniqid();
 						},
 					),
-					'parentId'                => array(
+					'parentClientId'                => array(
 						'type'        => 'String',
 						'description' => __( 'The parent id of the Block', 'wp-graphql-content-blocks' ),
 						'resolve'     => function ( $block ) {
-							return isset( $block['parentId'] ) ? $block['parentId'] : null;
+							return isset( $block['parentClientId'] ) ? $block['parentClientId'] : null;
 						},
 					),
 					'name'                    => array(

--- a/tests/unit/BlockQueriesTest.php
+++ b/tests/unit/BlockQueriesTest.php
@@ -76,7 +76,7 @@ final class BlockQueriesTest extends PluginTestCase {
 					databaseId
 					editorBlocks(flat: true) {
                         name
-                        parentId
+                        parentClientId
                     }
 				}
 			}
@@ -93,19 +93,19 @@ final class BlockQueriesTest extends PluginTestCase {
 		$this->assertEquals( count( $node['editorBlocks'] ), 5 );
 
 		$this->assertEquals( $node['editorBlocks'][0]['name'], 'core/columns' );
-		$this->assertNull( $node['editorBlocks'][0]['parentId'] );
+		$this->assertNull( $node['editorBlocks'][0]['parentClientId'] );
 
 		$this->assertEquals( $node['editorBlocks'][1]['name'], 'core/column' );
-		$this->assertNotNull( $node['editorBlocks'][1]['parentId'] );
+		$this->assertNotNull( $node['editorBlocks'][1]['parentClientId'] );
 
 		$this->assertEquals( $node['editorBlocks'][2]['name'], 'core/paragraph' );
-		$this->assertNotNull( $node['editorBlocks'][2]['parentId'] );
+		$this->assertNotNull( $node['editorBlocks'][2]['parentClientId'] );
 
 		$this->assertEquals( $node['editorBlocks'][3]['name'], 'core/column' );
-		$this->assertNotNull( $node['editorBlocks'][3]['parentId'] );
+		$this->assertNotNull( $node['editorBlocks'][3]['parentClientId'] );
 
 		$this->assertEquals( $node['editorBlocks'][4]['name'], 'core/paragraph' );
-		$this->assertNotNull( $node['editorBlocks'][4]['parentId'] );
+		$this->assertNotNull( $node['editorBlocks'][4]['parentClientId'] );
 	}
 
 }

--- a/tests/unit/ContentBlockInterfaceTest.php
+++ b/tests/unit/ContentBlockInterfaceTest.php
@@ -112,7 +112,7 @@ final class EditorBlockInterfaceTest extends PluginTestCase {
 		$this->assertArrayHasKey( 'data', $response, json_encode( $response ) );
 		$actual = array_map( function ($val) { return $val['name']; } , $response['data']['__type']['fields'] );
 		sort( $actual );
-		sort( $expected);
+		sort( $expected );
 		$this->assertEquals( $actual , $expected );
 	}
 }

--- a/tests/unit/ContentBlockInterfaceTest.php
+++ b/tests/unit/ContentBlockInterfaceTest.php
@@ -110,7 +110,9 @@ final class EditorBlockInterfaceTest extends PluginTestCase {
 			'renderedHtml',
 		);
 		$this->assertArrayHasKey( 'data', $response, json_encode( $response ) );
-		$fields = array_map( function ($val) { return $val['name']; } , $response['data']['__type']['fields'] );
-		$this->assertEquals( $fields , $expected );
+		$actual = array_map( function ($val) { return $val['name']; } , $response['data']['__type']['fields'] );
+		natsort( $actual );
+		natsort( $expected);
+		$this->assertEquals( $actual , $expected );
 	}
 }

--- a/tests/unit/ContentBlockInterfaceTest.php
+++ b/tests/unit/ContentBlockInterfaceTest.php
@@ -119,10 +119,10 @@ final class EditorBlockInterfaceTest extends PluginTestCase {
 					'name' => 'name',
 				),
 				array(
-					'name' => 'nodeId',
+					'name' => 'clientId',
 				),
 				array(
-					'name' => 'parentId',
+					'name' => 'parentClientId',
 				),
 				array(
 					'name' => 'renderedHtml',

--- a/tests/unit/ContentBlockInterfaceTest.php
+++ b/tests/unit/ContentBlockInterfaceTest.php
@@ -99,37 +99,18 @@ final class EditorBlockInterfaceTest extends PluginTestCase {
 			)
 		);
 		$expected = array(
-			'fields' => array(
-				array(
-					'name' => 'apiVersion',
-				),
-				array(
-					'name' => 'blockEditorCategoryName',
-				),
-				array(
-					'name' => 'cssClassNames',
-				),
-				array(
-					'name' => 'innerBlocks',
-				),
-				array(
-					'name' => 'isDynamic',
-				),
-				array(
-					'name' => 'name',
-				),
-				array(
-					'name' => 'clientId',
-				),
-				array(
-					'name' => 'parentClientId',
-				),
-				array(
-					'name' => 'renderedHtml',
-				),
-			),
+			'apiVersion',
+			'blockEditorCategoryName',
+			'cssClassNames',
+			'innerBlocks',
+			'isDynamic',
+			'name',
+			'clientId',
+			'parentClientId',
+			'renderedHtml',
 		);
 		$this->assertArrayHasKey( 'data', $response, json_encode( $response ) );
-		$this->assertEquals( $response['data']['__type'], $expected );
+		$fields = array_map( function ($val) { return $val['name']; } , $response['data']['__type']['fields'] );
+		$this->assertEquals( $fields , $expected );
 	}
 }

--- a/tests/unit/ContentBlockInterfaceTest.php
+++ b/tests/unit/ContentBlockInterfaceTest.php
@@ -111,8 +111,8 @@ final class EditorBlockInterfaceTest extends PluginTestCase {
 		);
 		$this->assertArrayHasKey( 'data', $response, json_encode( $response ) );
 		$actual = array_map( function ($val) { return $val['name']; } , $response['data']['__type']['fields'] );
-		natsort( $actual );
-		natsort( $expected);
+		sort( $actual );
+		sort( $expected);
 		$this->assertEquals( $actual , $expected );
 	}
 }

--- a/tests/unit/UnknownBlockTest.php
+++ b/tests/unit/UnknownBlockTest.php
@@ -2,19 +2,23 @@
 
 namespace WPGraphQL\ContentBlocks\Unit;
 
-final class UnknownBlockTest extends PluginTestCase
-{
-  public $instance;
-  public $post_id;
+final class UnknownBlockTest extends PluginTestCase {
 
-  public function setUp(): void
-  {
-    parent::setUp();
-    global $wpdb;
+	public $instance;
+	public $post_id;
 
-    $this->post_id = wp_insert_post([
-      'post_title'   => 'Post Title',
-      'post_content' => preg_replace('/\s+/', ' ', trim('
+	public function setUp(): void {
+		parent::setUp();
+		global $wpdb;
+
+		$this->post_id = wp_insert_post(
+			array(
+				'post_title'   => 'Post Title',
+				'post_content' => preg_replace(
+					'/\s+/',
+					' ',
+					trim(
+						'
         <!-- wp:paragraph -->
         <p>Testing</p>
         <!-- /wp:paragraph -->
@@ -26,28 +30,28 @@ final class UnknownBlockTest extends PluginTestCase
         <!-- wp:testing -->
         <p>Testing</p>
         <!-- /wp:testing -->
-      ')),
-      'post_status'  => 'publish'
-    ]);
-  }
+      '
+					)
+				),
+				'post_status'  => 'publish',
+			)
+		);
+	}
 
-  public function tearDown(): void
-  {
-    // your tear down methods here
-    parent::tearDown();
-    wp_delete_post($this->post_id, true);
-  }
+	public function tearDown(): void {
+		// your tear down methods here
+		parent::tearDown();
+		wp_delete_post( $this->post_id, true );
+	}
 
-  public function test_retrieve_content_blocks()
-  {
-    $query = '
+	public function test_retrieve_content_blocks() {
+		$query = '
 		{
 			posts(first: 1) {
 				nodes {
 					databaseId
           editorBlocks(flat: true) {
               name
-              parentId
               renderedHtml
           }
 				}
@@ -55,20 +59,20 @@ final class UnknownBlockTest extends PluginTestCase
 		}
 		';
 
-    $actual = graphql(['query' => $query]);
-    $node = $actual['data']['posts']['nodes'][0];
+		$actual = graphql( array( 'query' => $query ) );
+		$node   = $actual['data']['posts']['nodes'][0];
 
-    // Verify that the ID of the first post matches the one we just created.
-    $this->assertEquals($this->post_id, $node['databaseId']);
+		// Verify that the ID of the first post matches the one we just created.
+		$this->assertEquals( $this->post_id, $node['databaseId'] );
 
-    // Verify 3 blocks are returned
-    $this->assertEquals(count($node['editorBlocks']), 3);
+		// Verify 3 blocks are returned
+		$this->assertEquals( count( $node['editorBlocks'] ), 3 );
 
-    $this->assertEquals($node['editorBlocks'][0]['name'], 'core/paragraph');
+		$this->assertEquals( $node['editorBlocks'][0]['name'], 'core/paragraph' );
 
-    $this->assertEquals($node['editorBlocks'][1]['name'], 'core/heading');
-    
-    $this->assertEquals($node['editorBlocks'][2]['name'], 'UnknownBlock');
-    $this->assertEquals($node['editorBlocks'][2]['renderedHtml'], ' <p>Testing</p> ');
-  }
+		$this->assertEquals( $node['editorBlocks'][1]['name'], 'core/heading' );
+
+		$this->assertEquals( $node['editorBlocks'][2]['name'], 'UnknownBlock' );
+		$this->assertEquals( $node['editorBlocks'][2]['renderedHtml'], ' <p>Testing</p> ' );
+	}
 }


### PR DESCRIPTION
This PR causes a BREAKING change:

It changes `nodeId` -> `clientId` and `parentId` -> `parentClientId` as per recommendation 
https://github.com/wpengine/wp-graphql-content-blocks/issues/15

## Testing

Make sure you check that the new fields are `clientId` and `parentClientId` on the `contentBlocks`