### PR TITLE
BREAKING! Refactor: Change contentBlocks -> editorBlocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,15 +21,15 @@ There is no other configuration needed once you install the plugin.
 ## Getting started
 
 Once the plugin is installed, head over to the GraphiQL IDE and you should be able to perform queries for the block data (This plugin is an extension of [wp-graphql](https://www.wpgraphql.com/), so make sure you have it installed first.).
-There is a new field added in the Post and Page models called `contentBlocks`.
+There is a new field added in the Post and Page models called `editorBlocks`.
 This represents a list of available blocks for that content type:
 
 ```graphql
 {
   posts {
     nodes {
-      # contentBlocks field represents array of Block data
-      contentBlocks {
+      # editorBlocks field represents array of Block data
+      editorBlocks {
         # fields from the interface
         renderedHtml
         __typename
@@ -53,14 +53,14 @@ This represents a list of available blocks for that content type:
 
 ## How do I query block data?
 
-To query specific block data you need to define that data in the `contentBlock` as the appropriate type.
+To query specific block data you need to define that data in the `editorBlocks` as the appropriate type.
 For example, to use `CoreParagraph` attributes you need to use the following query:
 
 ```graphql
 {
   posts {
     nodes {
-      contentBlocks {
+      editorBlocks {
         __typename
         name
         ...on CoreParagraph {
@@ -90,7 +90,7 @@ If the resolved block has values for those fields, it will return them, otherwis
 
 ## What about innerBlocks?
 
-In order to facilitate querying `innerBlocks` fields more efficiently you want to use `contentBlocks(flat: true)` instead of `contentBlocks`.
+In order to facilitate querying `innerBlocks` fields more efficiently you want to use `editorBlocks(flat: true)` instead of `editorBlocks`.
 By passing this argument, all the blocks available (both blocks and innerBlocks) will be returned all flattened in the same list.
 
 For example, given the following HTML Content:

--- a/includes/Blocks/Block.php
+++ b/includes/Blocks/Block.php
@@ -180,7 +180,7 @@ class Block {
 			$this->type_name,
 			array(
 				'description'     => __( 'A block used for editing the site', 'wp-graphql-content-blocks' ),
-				'interfaces'      => array( 'ContentBlock' ),
+				'interfaces'      => array( 'EditorBlock' ),
 				'eagerlyLoadType' => true,
 				'fields'          => array(
 					'name' => array(

--- a/includes/Registry/Registry.php
+++ b/includes/Registry/Registry.php
@@ -7,7 +7,7 @@ use WP_Block_Type;
 use WPGraphQL\ContentBlocks\Blocks\Block;
 use WPGraphQL\ContentBlocks\Interfaces\OnInit;
 use WPGraphQL\ContentBlocks\Type\Scalar\Scalar;
-use WPGraphQL\ContentBlocks\Type\InterfaceType\ContentBlockInterface;
+use WPGraphQL\ContentBlocks\Type\InterfaceType\EditorBlockInterface;
 use WPGraphQL\Registry\TypeRegistry;
 use WPGraphQL\Utils\Utils;
 
@@ -51,7 +51,7 @@ final class Registry implements OnInit {
 	 * @throws Exception
 	 */
 	public function OnInit() {
-		ContentBlockInterface::register_type( $this->type_registry );
+		EditorBlockInterface::register_type( $this->type_registry );
 		( new Scalar() )->OnInit();
 		$this->pass_blocks_to_context();
 		$this->register_block_types();
@@ -69,7 +69,7 @@ final class Registry implements OnInit {
 			'UnknownBlock',
 			array(
 				'description'     => __( 'A block used for resolving blocks not found in the WordPress registry', 'wp-graphql-content-blocks' ),
-				'interfaces'      => array( 'ContentBlock' ),
+				'interfaces'      => array( 'EditorBlock' ),
 				'eagerlyLoadType' => true,
 				'fields'          => array(
 					'name' => array(
@@ -158,8 +158,8 @@ final class Registry implements OnInit {
 			return;
 		}
 
-		// Register the `NodeWithContentBlocks` Interface to the supported post types
-		register_graphql_interfaces_to_types( array( 'NodeWithContentBlocks' ), $supported_post_types );
+		// Register the `NodeWithEditorBlocks` Interface to the supported post types
+		register_graphql_interfaces_to_types( array( 'NodeWithEditorBlocks' ), $supported_post_types );
 	}
 
 	/**

--- a/includes/Type/InterfaceType/EditorBlockInterface.php
+++ b/includes/Type/InterfaceType/EditorBlockInterface.php
@@ -10,11 +10,11 @@ use WPGraphQL\Utils\Utils;
 use WPGraphQL\ContentBlocks\Data\ContentBlocksResolver;
 
 /**
- * Class ContentBlockInterface
+ * Class EditorBlockInterface
  *
  * @package WPGraphQL\ContentBlocks
  */
-final class ContentBlockInterface {
+final class EditorBlockInterface {
 
 
 	/**
@@ -44,21 +44,21 @@ final class ContentBlockInterface {
 	 */
 	public static function register_type( TypeRegistry $type_registry ) {
 		register_graphql_interface_type(
-			'NodeWithContentBlocks',
+			'NodeWithEditorBlocks',
 			array(
 				'description'     => __( 'Node that has content blocks associated with it', 'wp-graphql-content-blocks' ),
 				'eagerlyLoadType' => true,
 				'fields'          => array(
-					'contentBlocks' => array(
+					'editorBlocks' => array(
 						'type'        => array(
-							'list_of' => 'ContentBlock',
+							'list_of' => 'EditorBlock',
 						),
 						'args'        => array(
 							'flat' => array(
 								'type' => 'Boolean',
 							),
 						),
-						'description' => __( 'List of content blocks', 'wp-graphql-content-blocks' ),
+						'description' => __( 'List of editor blocks', 'wp-graphql-content-blocks' ),
 						'resolve'     => function ( $node, $args ) {
 							return ContentBlocksResolver::resolve_content_blocks( $node, $args );
 						},
@@ -67,9 +67,9 @@ final class ContentBlockInterface {
 			)
 		);
 
-		// Register the ContentBlock Interface
+		// Register the EditorBlock Interface
 		register_graphql_interface_type(
-			'ContentBlock',
+			'EditorBlock',
 			array(
 				'eagerlyLoadType' => true,
 				'description'     => __( 'Blocks that can be edited to create content and layouts', 'wp-graphql-content-blocks' ),
@@ -115,7 +115,7 @@ final class ContentBlockInterface {
 					),
 					'innerBlocks'             => array(
 						'type'        => array(
-							'list_of' => 'ContentBlock',
+							'list_of' => 'EditorBlock',
 						),
 						'description' => __( 'The inner blocks of the Block', 'wp-graphql-content-blocks' ),
 						'resolve'     => function ( $block ) {

--- a/tests/unit/BlockAttributesObjectTest.php
+++ b/tests/unit/BlockAttributesObjectTest.php
@@ -40,13 +40,13 @@ final class BlockAttributesObjectTest extends PluginTestCase {
 			posts(first: 1) {
 				nodes {
 					databaseId
-						contentBlocks(flat: true) {
-							...on CoreParagraph {
-								attributes {
-									style
-								}
+					editorBlocks(flat: true) {
+						...on CoreParagraph {
+							attributes {
+								style
 							}
 						}
+					}
 				}
 			}
 		}
@@ -58,8 +58,8 @@ final class BlockAttributesObjectTest extends PluginTestCase {
 		// Verify that the ID of the first post matches the one we just created.
 		$this->assertEquals( $this->post_id, $node['databaseId'] );
 		// There should be only 1 block
-		$this->assertEquals( count( $node['contentBlocks'] ), 1 );
+		$this->assertEquals( count( $node['editorBlocks'] ), 1 );
 		// There should be a style attribute that matches the json for the content of the attribute
-		$this->assertEquals( $node['contentBlocks'][0]['attributes']['style'], '{"color":{"background":"#a62929"}}' );
+		$this->assertEquals( $node['editorBlocks'][0]['attributes']['style'], '{"color":{"background":"#a62929"}}' );
 	}
 }

--- a/tests/unit/BlockQueriesTest.php
+++ b/tests/unit/BlockQueriesTest.php
@@ -44,15 +44,15 @@ final class BlockQueriesTest extends PluginTestCase {
 		wp_delete_post( $this->post_id, true );
 	}
 
-	public function test_retrieve_non_flatten_content_blocks() {
+	public function test_retrieve_non_flatten_editor_blocks() {
 		$query  = '
 		{
 			posts(first: 1) {
 				nodes {
 					databaseId
-                    			contentBlocks {
-                        			name
-                    			}
+                    editorBlocks {
+                    	name
+                    }
 				}
 			}
 		}
@@ -64,20 +64,20 @@ final class BlockQueriesTest extends PluginTestCase {
 		$this->assertEquals( $this->post_id, $node['databaseId'] );
 
 		// There should be only one block using that query when not using flat: true
-		$this->assertEquals( count( $node['contentBlocks'] ), 1 );
-		$this->assertEquals( $node['contentBlocks'][0]['name'], 'core/columns' );
+		$this->assertEquals( count( $node['editorBlocks'] ), 1 );
+		$this->assertEquals( $node['editorBlocks'][0]['name'], 'core/columns' );
 	}
 
-	public function test_retrieve_flatten_content_blocks() {
+	public function test_retrieve_flatten_editor_blocks() {
 		$query = '
 		{
 			posts(first: 1) {
 				nodes {
 					databaseId
-                    			contentBlocks(flat: true) {
-                        			name
-                        			parentId
-                    			}
+					editorBlocks(flat: true) {
+                        name
+                        parentId
+                    }
 				}
 			}
 		}
@@ -90,22 +90,22 @@ final class BlockQueriesTest extends PluginTestCase {
 		$this->assertEquals( $this->post_id, $node['databaseId'] );
 
 		// There should more than one block using that query when using flat: true
-		$this->assertEquals( count( $node['contentBlocks'] ), 5 );
+		$this->assertEquals( count( $node['editorBlocks'] ), 5 );
 
-		$this->assertEquals( $node['contentBlocks'][0]['name'], 'core/columns' );
-		$this->assertNull( $node['contentBlocks'][0]['parentId'] );
+		$this->assertEquals( $node['editorBlocks'][0]['name'], 'core/columns' );
+		$this->assertNull( $node['editorBlocks'][0]['parentId'] );
 
-		$this->assertEquals( $node['contentBlocks'][1]['name'], 'core/column' );
-		$this->assertNotNull( $node['contentBlocks'][1]['parentId'] );
+		$this->assertEquals( $node['editorBlocks'][1]['name'], 'core/column' );
+		$this->assertNotNull( $node['editorBlocks'][1]['parentId'] );
 
-		$this->assertEquals( $node['contentBlocks'][2]['name'], 'core/paragraph' );
-		$this->assertNotNull( $node['contentBlocks'][2]['parentId'] );
+		$this->assertEquals( $node['editorBlocks'][2]['name'], 'core/paragraph' );
+		$this->assertNotNull( $node['editorBlocks'][2]['parentId'] );
 
-		$this->assertEquals( $node['contentBlocks'][3]['name'], 'core/column' );
-		$this->assertNotNull( $node['contentBlocks'][3]['parentId'] );
+		$this->assertEquals( $node['editorBlocks'][3]['name'], 'core/column' );
+		$this->assertNotNull( $node['editorBlocks'][3]['parentId'] );
 
-		$this->assertEquals( $node['contentBlocks'][4]['name'], 'core/paragraph' );
-		$this->assertNotNull( $node['contentBlocks'][4]['parentId'] );
+		$this->assertEquals( $node['editorBlocks'][4]['name'], 'core/paragraph' );
+		$this->assertNotNull( $node['editorBlocks'][4]['parentId'] );
 	}
 
 }

--- a/tests/unit/ContentBlockInterfaceTest.php
+++ b/tests/unit/ContentBlockInterfaceTest.php
@@ -2,9 +2,9 @@
 
 namespace WPGraphQL\ContentBlocks\Unit;
 
-use \WPGraphQL\ContentBlocks\Type\InterfaceType\ContentBlockInterface;
+use \WPGraphQL\ContentBlocks\Type\InterfaceType\EditorBlockInterface;
 
-final class ContentBlockInterfaceTest extends PluginTestCase {
+final class EditorBlockInterfaceTest extends PluginTestCase {
 
 	public $instance;
 	public function setUp(): void {
@@ -14,7 +14,7 @@ final class ContentBlockInterfaceTest extends PluginTestCase {
 		$settings['public_introspection_enabled'] = 'on';
 		update_option( 'graphql_general_settings', $settings );
 
-		$this->instance = new ContentBlockInterface();
+		$this->instance = new EditorBlockInterface();
 	}
 
 	public function tearDown(): void {
@@ -25,7 +25,7 @@ final class ContentBlockInterfaceTest extends PluginTestCase {
 	}
 
 	/**
-	 * @covers ContentBlockInterface->get_block
+	 * @covers EditorBlockInterface->get_block
 	 */
 	public function test_get_block() {
 		$block_exists                                = array(
@@ -47,12 +47,12 @@ final class ContentBlockInterfaceTest extends PluginTestCase {
 	}
 
 	/**
-	 * @covers ContentBlockInterface->register_type
+	 * @covers EditorBlockInterface->register_type
 	 */
 	public function test_register_type() {
-		$queryNodeWithContentBlocksMeta = '
-		query NodeWithContentBlocksMeta {
-            __type(name: "NodeWithContentBlocks") {
+		$queryNodeWithEditorBlocksMeta = '
+		query NodeWithEditorBlocksMeta {
+            __type(name: "NodeWithEditorBlocks") {
               fields {
                 name
               }
@@ -60,19 +60,19 @@ final class ContentBlockInterfaceTest extends PluginTestCase {
           }
 		';
 
-		// Verify NodeWithContentBlocks fields registration
+		// Verify NodeWithEditorBlocks fields registration
 		$response = graphql(
 			array(
-				'query'     => $queryNodeWithContentBlocksMeta,
+				'query'     => $queryNodeWithEditorBlocksMeta,
 				'variables' => array(
-					'name' => 'NodeWithContentBlocks',
+					'name' => 'NodeWithEditorBlocks',
 				),
 			)
 		);
 		$expected = array(
 			'fields' => array(
 				array(
-					'name' => 'contentBlocks',
+					'name' => 'editorBlocks',
 				),
 			),
 		);
@@ -81,7 +81,7 @@ final class ContentBlockInterfaceTest extends PluginTestCase {
 
 		$queryContentBlockMeta = '
 		query ContentBlockMeta {
-            __type(name: "ContentBlock") {
+            __type(name: "EditorBlock") {
               fields {
                 name
               }
@@ -94,7 +94,7 @@ final class ContentBlockInterfaceTest extends PluginTestCase {
 			array(
 				'query'     => $queryContentBlockMeta,
 				'variables' => array(
-					'name' => 'ContentBlock',
+					'name' => 'EditorBlock',
 				),
 			)
 		);

--- a/tests/unit/RegistryTestCase.php
+++ b/tests/unit/RegistryTestCase.php
@@ -70,7 +70,7 @@ final class RegistryTest extends PluginTestCase {
 			)
 		);
 		$contains_interface = array(
-			'name'        => 'NodeWithContentBlocks',
+			'name'        => 'NodeWithEditorBlocks',
 			'description' => 'Node that has content blocks associated with it',
 		);
 		$this->assertArrayHasKey( 'data', $response, json_encode( $response ) );

--- a/tests/unit/UnknownBlockTest.php
+++ b/tests/unit/UnknownBlockTest.php
@@ -45,7 +45,7 @@ final class UnknownBlockTest extends PluginTestCase
 			posts(first: 1) {
 				nodes {
 					databaseId
-          contentBlocks(flat: true) {
+          editorBlocks(flat: true) {
               name
               parentId
               renderedHtml
@@ -62,13 +62,13 @@ final class UnknownBlockTest extends PluginTestCase
     $this->assertEquals($this->post_id, $node['databaseId']);
 
     // Verify 3 blocks are returned
-    $this->assertEquals(count($node['contentBlocks']), 3);
+    $this->assertEquals(count($node['editorBlocks']), 3);
 
-    $this->assertEquals($node['contentBlocks'][0]['name'], 'core/paragraph');
+    $this->assertEquals($node['editorBlocks'][0]['name'], 'core/paragraph');
 
-    $this->assertEquals($node['contentBlocks'][1]['name'], 'core/heading');
+    $this->assertEquals($node['editorBlocks'][1]['name'], 'core/heading');
     
-    $this->assertEquals($node['contentBlocks'][2]['name'], 'UnknownBlock');
-    $this->assertEquals($node['contentBlocks'][2]['renderedHtml'], ' <p>Testing</p> ');
+    $this->assertEquals($node['editorBlocks'][2]['name'], 'UnknownBlock');
+    $this->assertEquals($node['editorBlocks'][2]['renderedHtml'], ' <p>Testing</p> ');
   }
 }


### PR DESCRIPTION
This PR changes `contentBlocks` field to `editorBlocks` in all places including the documentation

## JIRA
[MERL-727](https://wpengine.atlassian.net/browse/MERL-727)

## Testing
* Load GraphQLi
* Check that the old field is not available
* Check that the new field is available.

[MERL-727]: https://wpengine.atlassian.net/browse/MERL-727?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

##  Screenshots
<img width="1527" alt="Screenshot 2023-03-02 at 11 15 49" src="https://user-images.githubusercontent.com/328805/222415999-47f85873-ee6e-4660-9ac0-629c573ccc75.png">

