### PR TITLE
fix: illegal index error fixed in Block.php

### DIFF
--- a/includes/Blocks/Block.php
+++ b/includes/Blocks/Block.php
@@ -146,6 +146,7 @@ class Block {
 					case 'boolean':
 						$graphql_type = 'Boolean';
 						break;
+					case 'array':
 					case 'object':
 						$graphql_type = Scalar::BlockAttributesObject();
 						break;
@@ -200,24 +201,28 @@ class Block {
 	}
 
 	private function resolve_block_attributes( $block, $attribute_name, $attribute_config ) {
+		// Get default value.
+		$default = isset( $attribute_config['default'] ) ? $attribute_config['default'] : null;
+		
 		if ( isset( $attribute_config['selector'], $attribute_config['source'] ) ) {
 			$rendered_block = wp_unslash( render_block( $block ) );
 			$value          = null;
 			if ( empty( $rendered_block ) ) {
 				return $value;
 			}
+			
 			switch ( $attribute_config['source'] ) {
 				case 'attribute':
-					$value = DOMHelpers::parseAttribute( $rendered_block, $attribute_config['selector'], $attribute_config['attribute'], $attribute_config['default'] );
+					$value = DOMHelpers::parseAttribute( $rendered_block, $attribute_config['selector'], $attribute_config['attribute'], $default );
 					break;
 				case 'html':
-					$value = DOMHelpers::parseHTML( $rendered_block, $attribute_config['selector'], $attribute_config['default'] );
+					$value = DOMHelpers::parseHTML( $rendered_block, $attribute_config['selector'], $default );
 					break;
 			}//end switch
 
 			return $value;
 		}//end if
-		$default = isset( $attribute_config['default'] ) ? $attribute_config['default'] : null;
+
 		return $block['attrs'][ $attribute_name ] ?? $default;
 	}
 }


### PR DESCRIPTION
# Summary

![image](https://user-images.githubusercontent.com/13604318/224388618-aa2c9d78-9c39-422e-9790-c13d8bec1ef7.png)

I noticed this error in my Docker console as I would run queries with `editorBlocks` in them, so I just moved the assignment of `$default` above the `if` statement in the `Block::resolve_block_attributes()` function, replaced the following usages of `$attribute_config['default']` with `$default`.


