### PR TITLE
Changed flatlist to true by default

### DIFF
--- a/.changeset/smooth-deers-admire.md
+++ b/.changeset/smooth-deers-admire.md
@@ -2,4 +2,4 @@
 "@wpengine/wp-graphql-content-blocks": patch
 ---
 
-Changed flatlist to true by default
+- __[BREAKING]__ Changed `flatlist` to true by default

--- a/.changeset/smooth-deers-admire.md
+++ b/.changeset/smooth-deers-admire.md
@@ -1,0 +1,5 @@
+---
+"@wpengine/wp-graphql-content-blocks": patch
+---
+
+Changed flatlist to true by default

--- a/includes/Data/ContentBlocksResolver.php
+++ b/includes/Data/ContentBlocksResolver.php
@@ -67,8 +67,8 @@ final class ContentBlocksResolver {
 			$parsed_blocks
 		);
 
-		// Flatten block list here if requested
-		if ( isset( $args['flat'] ) && 'true' == $args['flat'] ) {
+		// Flatten block list here if requested or if 'flat' value is not selected (default)
+		if ( !isset( $args['flat'] ) || 'true' == $args['flat'] ) {
 			return self::flatten_block_list( $parsed_blocks );
 		}
 		return $parsed_blocks;

--- a/tests/unit/BlockQueriesTest.php
+++ b/tests/unit/BlockQueriesTest.php
@@ -50,7 +50,7 @@ final class BlockQueriesTest extends PluginTestCase {
 			posts(first: 1) {
 				nodes {
 					databaseId
-                    editorBlocks {
+                    editorBlocks(flat: false) {
                     	name
                     }
 				}


### PR DESCRIPTION
This PR is for one of two to fulfill [MERL-759](https://wpengine.atlassian.net/jira/software/c/projects/MERL/boards/1007?modal=detail&selectedIssue=MERL-759). It sets editorBlocks to use ( flat: true ) by default. The test case for a non-flattened  editor block was also updated to have the `flat` arg set to explicitly false.

[MERL-759]: https://wpengine.atlassian.net/browse/MERL-759?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

To test: 

Spin up a site in Local and add the most recent `wp-graphql-content-blocks` plugin to the plugin folder.
After installing Faust and WPGraphQL, head to posts and create a gallery of photos.
<img width="761" alt="image" src="https://user-images.githubusercontent.com/50935135/225419220-b773b982-6049-43aa-8ea1-6d30f73fab06.png">
Check `editorBlocks` in the GraphiQL IDE returns a flat list of blocks:
<img width="1518" alt="image" src="https://user-images.githubusercontent.com/50935135/225420613-0e391391-448f-4535-8ab6-9ef43214ab4e.png">
