### PR TITLE
Warn the user if they downloaded the source code .zip

### DIFF
--- a/.changeset/lovely-doors-hammer.md
+++ b/.changeset/lovely-doors-hammer.md
@@ -1,0 +1,5 @@
+---
+"@wpengine/wp-graphql-content-blocks": patch
+---
+
+Warn the user if they downloaded the source code .zip instead of the production ready .zip file

--- a/includes/WPGraphQLContentBlocks.php
+++ b/includes/WPGraphQLContentBlocks.php
@@ -100,6 +100,24 @@ final class WPGraphQLContentBlocks {
 			if ( file_exists( WPGRAPHQL_CONTENT_BLOCKS_PLUGIN_DIR . 'vendor/autoload.php' ) ) {
 				// Autoload Required Classes.
 				require_once WPGRAPHQL_CONTENT_BLOCKS_PLUGIN_DIR . 'vendor/autoload.php';
+			} else {
+				add_action(
+					'admin_notices',
+					function () {
+
+						if ( ! current_user_can( 'manage_options' ) ) {
+							return;
+						}
+
+						echo sprintf(
+							'<div class="notice notice-error">' .
+							'<p>%s</p>' .
+							'</div>',
+							__( 'WPGraphQL Content Blocks appears to have been installed without it\'s dependencies. If you meant to download the source code, you can run `composer install` to install dependencies. If you are looking for the production version of the plugin, you can download it from the <a target="_blank" href="https://github.com/wpengine/wp-graphql-content-blocks/releases">GitHub Releases tab.</a>', 'wp-graphql' )
+						);
+					}
+				);
+
 			}
 
 			// If GraphQL class doesn't exist, then dependencies cannot be
@@ -135,7 +153,7 @@ final class WPGraphQLContentBlocks {
 	 * @since 0.0.1
 	 */
 	public function actions() {
-		 add_action( 'graphql_register_types', array( $this, 'init_block_editor_registry' ) );
+		add_action( 'graphql_register_types', array( $this, 'init_block_editor_registry' ) );
 	}
 
 	public function filters() {     }


### PR DESCRIPTION
It's sometimes habit to download the `main` .zip from GitHub without actually downloading the production version from the "releases" tab. This PR adds a warning if the prod `vendor` directory isn't found and instructs the user to either run `composer install` if they meant to download the source code or download the production ready version from the releases tab.