### PR TITLE
feat: define config field implemented.

### DIFF
--- a/includes/Blocks/Block.php
+++ b/includes/Blocks/Block.php
@@ -133,6 +133,15 @@ class Block {
 					return $block_attribute_fields;
 				}
 
+				if ( isset( $attribute_config['define'] ) ) {
+					$definition = $attribute_config['define'];
+					if ( ! empty( $definition['resolve'] ) && 'string' === gettype( $definition['resolve'] ) ) {
+						$definition['resolve'] = [ $this, $definition['resolve'] ];
+					}
+					$block_attribute_fields[ Utils::format_field_name( $attribute_name ) ] = $definition;
+					continue;
+				}
+
 				switch ( $attribute_config['type'] ) {
 					case 'string':
 						$graphql_type = 'String';
@@ -200,7 +209,7 @@ class Block {
 		return isset( $block['blockName'] ) ? $block['blockName'] : '';
 	}
 
-	private function resolve_block_attributes( $block, $attribute_name, $attribute_config ) {
+	protected function resolve_block_attributes( $block, $attribute_name, $attribute_config ) {
 		// Get default value.
 		$default = isset( $attribute_config['default'] ) ? $attribute_config['default'] : null;
 		


### PR DESCRIPTION
# Summary
Adds support for adding field type definition from the custom block class.

My reasoning for this was for blocks which rely on relationships with external data types, like CPTs, but only store reference keys to those objects, like a post ID.

Here's an example block class, I'm using in my current project. The focus is the `define` class field. 

```php
<?php
/**
 * Blocks class. Defines "Product And Cart Block" additional attributes.
 *
 * @package Axis\Content_Blocks
 */

namespace Axis\Content_Blocks;

use WPGraphQL\ContentBlocks\Blocks\Block;

/**
 * Product_And_Cart_Block class.
 */
class Product_And_Cart_Block extends Block {

	/**
	 * Block attribute definitions.
	 *
	 * @var array
	 */
	protected ?array $additional_block_attributes = [
		'selectedProduct' => [
			'type'   => 'object',
			'define' => [
				'type'        => 'Product',
				'description' => 'Block\'s selected product',
				'resolve'     => 'resolve_product',
			],
		],
	];

	/**
	 * "selectedProduct" field resolve function
	 *
	 * @param Product_And_Cart_Block $source Block.
	 * @param array                  $args   Field arguments.
	 * @param AppContext             $context AppContext instance.
	 *
	 * @return \WPGraphQL\WooCommerce\Model\Product|null
	 */
	public function resolve_product( $source, $args, $context ) {
		// Get relationship attribute config.
		$product_config = ! empty( $this->block_attributes['product'] ) ? $this->block_attributes['product'] : null;
		if ( ! $product_config ) {
			return null;
		}
		// Get Product ID as attribute value.
		$product_id = $this->resolve_block_attributes( $source, 'product', $product_config );

		// Resolve product if ID found.
		if ( absint( $product_id ) ) {
			return $context->get_loader( 'wc_post' )->load( absint( $product_id ) );
		}
		return null;
	}
}
```

The `resolve_product` is the actually resolve specified by `selectedProduct->define->resolve`. I would have preferred to have a `[ $this, 'resolve_product' ]`, but `$this` isn't a scalar. So the logic assumes it's a local class function if a string is provided as the `resolve` value.

I was should what would be the best approach to unit testing within the existing tests as its a mockery setup, didn't want to waste time mocking anything unnecessary, and figure it could wait until after the solution was picked apart and finalized 🤔. 

Me and @jasonbahl had discussed this functionally over a video call, and it became a significant requirement for statically generating pages that include dynamic blocks that don't render the output server side and use external data as mentioned above.