### PR TITLE
fix: slow schema / slow queries / unexpected Schema output

### DIFF
--- a/includes/Blocks/Block.php
+++ b/includes/Blocks/Block.php
@@ -169,6 +169,13 @@ class Block {
 	}
 
 	/**
+	 * @return string[]
+	 */
+	private function get_block_interfaces(): array {
+		return $this->block_registry->get_block_interfaces( $this->block->name );
+	}
+
+	/**
 	 * Register the Type for the block
 	 *
 	 * @return void
@@ -181,7 +188,7 @@ class Block {
 			$this->type_name,
 			array(
 				'description'     => __( 'A block used for editing the site', 'wp-graphql-content-blocks' ),
-				'interfaces'      => array( 'EditorBlock' ),
+				'interfaces'      => $this->get_block_interfaces( $this->block->name ),
 				'eagerlyLoadType' => true,
 				'fields'          => array(
 					'name' => array(
@@ -203,14 +210,14 @@ class Block {
 	private function resolve_block_attributes( $block, $attribute_name, $attribute_config ) {
 		// Get default value.
 		$default = isset( $attribute_config['default'] ) ? $attribute_config['default'] : null;
-		
+
 		if ( isset( $attribute_config['selector'], $attribute_config['source'] ) ) {
 			$rendered_block = wp_unslash( render_block( $block ) );
 			$value          = null;
 			if ( empty( $rendered_block ) ) {
 				return $value;
 			}
-			
+
 			switch ( $attribute_config['source'] ) {
 				case 'attribute':
 					$value = DOMHelpers::parseAttribute( $rendered_block, $attribute_config['selector'], $attribute_config['attribute'], $default );

--- a/includes/Blocks/CoreImage.php
+++ b/includes/Blocks/CoreImage.php
@@ -11,7 +11,7 @@ class CoreImage extends Block {
 			'source'    => 'attribute',
 			'attribute' => 'class',
 		),
-		'src'       => array(
+		'src'          => array(
 			'type'      => 'string',
 			'selector'  => 'img',
 			'source'    => 'attribute',

--- a/includes/Data/ContentBlocksResolver.php
+++ b/includes/Data/ContentBlocksResolver.php
@@ -67,7 +67,7 @@ final class ContentBlocksResolver {
 			},
 			$parsed_blocks
 		);
-		
+
 		// Flatten block list here if requested or if 'flat' value is not selected (default)
 		if ( ! isset( $args['flat'] ) || 'true' == $args['flat'] ) {
 			$parsed_blocks = self::flatten_block_list( $parsed_blocks );
@@ -78,7 +78,7 @@ final class ContentBlocksResolver {
 			$parsed_blocks = array_filter(
 				$parsed_blocks,
 				function ( $parsed_block ) use ( $allowed_block_names ) {
-					return isset( $parsed_block['blockName'] ) && in_array( $parsed_block['blockName'], $allowed_block_names, TRUE);
+					return isset( $parsed_block['blockName'] ) && in_array( $parsed_block['blockName'], $allowed_block_names, true );
 				},
 				ARRAY_FILTER_USE_BOTH
 			);

--- a/includes/Registry/Registry.php
+++ b/includes/Registry/Registry.php
@@ -36,6 +36,8 @@ final class Registry implements OnInit {
 	 */
 	public $registered_blocks;
 
+	public $block_interfaces = array();
+
 	/**
 	 * Registry constructor.
 	 *
@@ -60,11 +62,88 @@ final class Registry implements OnInit {
 	}
 
 	/**
+	 * Given the name of a block, return a list of Interfaces the block should implement to represent which contexts the block can be accessed from.
+	 *
+	 * i.e.
+	 * - a Block that is allowed on the "Post" post type will implement the "PostEditorBlock" interface
+	 * - a Block allowed on the "Page" post type will implement the "PageEditorBlock" interface
+	 * - a Block that is exposed in another context, for example NavMenu would implement the "NavMenuEditorBlock" interface (not yet supported)
+	 *
+	 * @param string $block_name The name of the block to get the interfaces for.
+	 *
+	 * @return array
+	 */
+	public function get_block_context_interfaces( string $block_name ): array {
+
+		// If there's already block interfaces defined for the block, return them
+		if ( ! empty( $this->block_interfaces[ $block_name ] ) ) {
+			return $this->block_interfaces[ $block_name ] ?? array();
+		}
+
+		// Get a list of Gutenberg and GraphQL enabled post types
+		$block_and_graphql_enabled_post_types = WPHelpers::get_supported_post_types();
+
+		if ( empty( $block_and_graphql_enabled_post_types ) ) {
+			return array();
+		}
+
+		$post_id = -1;
+
+		foreach ( $block_and_graphql_enabled_post_types as $post_type ) {
+			$type_name = strtolower( $post_type );
+
+			// retrieve a block_editor_context for the current post type
+			$block_editor_context = WPHelpers::get_block_editor_context( $post_type, $post_id-- );
+
+			// Fetch the list of allowed blocks for the current post type
+			$supported_blocks_for_post_type_context = get_allowed_block_types( $block_editor_context );
+
+			// If all blocks are supported in this context, we need a list of all the blocks
+			if ( true === $supported_blocks_for_post_type_context ) {
+				$supported_blocks_for_post_type_context = \WP_Block_Type_Registry::get_instance()->get_all_registered();
+				$supported_blocks_for_post_type_context = array_keys( $supported_blocks_for_post_type_context );
+			}
+
+			// If there are no supported blocks, return an empty array
+			if ( empty( $supported_blocks_for_post_type_context ) ) {
+				return array();
+			}
+
+			// Push the Contextual Interface for each supported Block to the block_interfaces array
+			array_map(
+				function( $supported_block ) use ( $type_name ) {
+					$this->block_interfaces[ $supported_block ][] = Utils::format_type_name( $type_name . 'EditorBlock' );
+				},
+				$supported_blocks_for_post_type_context
+			);
+		}//end foreach
+
+		return $this->block_interfaces[ $this->block->name ] ?? array();
+	}
+
+	/**
+	 * Given the name of a Block, return interfaces the Block should implement.
+	 *
+	 * @param string $block_name
+	 *
+	 * @return string[]
+	 */
+	public function get_block_interfaces( string $block_name ): array {
+
+		// Get the interfaces a block should implement based on the context a block is available to be accessed from.
+		$context_interfaces = $this->get_block_context_interfaces( $block_name );
+
+		// @todo: if blocks need to implement other interfaces (i.e. "BlockSupports" interfaces, that could be handled here as well)
+		return array_merge( array( 'EditorBlock' ), $context_interfaces );
+	}
+
+	/**
 	 * Register Interface types to the GraphQL Schema
 	 *
 	 * @return void
+	 * @throws Exception
 	 */
-	protected function register_interface_types() {
+	protected function register_interface_types(): void {
 		// First register the NodeWithEditorBlocks interface by default
 		EditorBlockInterface::register_type( $this->type_registry );
 
@@ -75,6 +154,7 @@ final class Registry implements OnInit {
 		}
 		register_graphql_interfaces_to_types( array( 'NodeWithEditorBlocks' ), $supported_post_types );
 		$post_id = -1;
+
 		// For each Post type
 		foreach ( $supported_post_types as $post_type ) {
 			// Normalize the post type name
@@ -86,24 +166,18 @@ final class Registry implements OnInit {
 			// Fetch the list of allowed blocks for the current post type
 			$supported_blocks_for_post_type = get_allowed_block_types( $block_editor_context );
 
+			if ( true === $supported_blocks_for_post_type ) {
+				$supported_blocks_for_post_type = \WP_Block_Type_Registry::get_instance()->get_all_registered();
+				$supported_blocks_for_post_type = array_keys( $supported_blocks_for_post_type );
+			}
+
 			// If there is a list of supported blocks for current post type
 			if ( is_array( $supported_blocks_for_post_type ) ) {
 				// Register an [PostType]Block type for the blocks using that post type
 				PostTypeBlockInterface::register_type( $type_name, $supported_blocks_for_post_type, $this->type_registry );
 
-				// Normalize the list of supported block names
-				$block_names = array_map(
-					function( $supported_block ) {
-						$block_name = preg_replace( '/\//', '', lcfirst( ucwords( $supported_block, '/' ) ) );
-						return \WPGraphQL\Utils\Utils::format_type_name( $block_name );
-					},
-					$supported_blocks_for_post_type
-				);
-				// Register [PostType]Block type to allowed block names
-				register_graphql_interfaces_to_types( array( $type_name . 'Block' ), $block_names );
-
 				// Register the `NodeWith[PostType]Blocks` Interface to the post type
-				register_graphql_interfaces_to_types( array( 'NodeWith' . $post_type . 'Blocks' ), array( $type_name ) );
+				register_graphql_interfaces_to_types( array( 'NodeWith' . $post_type . 'EditorBlocks' ), array( $type_name ) );
 			}
 		}//end foreach
 	}

--- a/includes/Type/InterfaceType/PostTypeBlockInterface.php
+++ b/includes/Type/InterfaceType/PostTypeBlockInterface.php
@@ -13,6 +13,7 @@ use WPGraphQL\Utils\Utils;
  * @package WPGraphQL\ContentBlocks
  */
 final class PostTypeBlockInterface {
+
 	/**
 	 * @param string        $post_type The post type
 	 * @param array(string) $$block_names The list of allowed block names
@@ -20,9 +21,9 @@ final class PostTypeBlockInterface {
 	 *
 	 * @throws Exception
 	 */
-	public static function register_type( $post_type, $block_names, TypeRegistry $type_registry ) {
+	public static function register_type( string $post_type, $block_names, TypeRegistry $type_registry ) {
 		register_graphql_interface_type(
-			ucfirst( $post_type ) . 'Block',
+			ucfirst( $post_type ) . 'EditorBlock',
 			array(
 				'interfaces'  => array( 'EditorBlock' ),
 				'fields'      => array(
@@ -43,8 +44,9 @@ final class PostTypeBlockInterface {
 				},
 			)
 		);
+
 		register_graphql_interface_type(
-			'NodeWith' . ucfirst( $post_type ) . 'Blocks',
+			'NodeWith' . ucfirst( $post_type ) . 'EditorBlocks',
 			array(
 				'description'     => __( 'Node that has ' . $post_type . ' content blocks associated with it', 'wp-graphql-content-blocks' ),
 				'eagerlyLoadType' => true,
@@ -52,7 +54,7 @@ final class PostTypeBlockInterface {
 				'fields'          => array(
 					'editorBlocks' => array(
 						'type'        => array(
-							'list_of' => ucfirst( $post_type ) . 'Block',
+							'list_of' => ucfirst( $post_type ) . 'EditorBlock',
 						),
 						'args'        => array(
 							'flat' => array(
@@ -68,4 +70,5 @@ final class PostTypeBlockInterface {
 			)
 		);
 	}
+
 }

--- a/includes/Type/ObjectType/UnknownBlock.php
+++ b/includes/Type/ObjectType/UnknownBlock.php
@@ -12,7 +12,6 @@ final class UnknownBlock {
 	/**
 	 * Registers the UnknownBlock in the instance a block is not defined
 	 * in the registry.
-     * 
 	 */
 	public static function register_type() {
 		register_graphql_object_type(

--- a/includes/WPGraphQLContentBlocks.php
+++ b/includes/WPGraphQLContentBlocks.php
@@ -104,7 +104,6 @@ final class WPGraphQLContentBlocks {
 				add_action(
 					'admin_notices',
 					function () {
-
 						if ( ! current_user_can( 'manage_options' ) ) {
 							return;
 						}
@@ -117,8 +116,7 @@ final class WPGraphQLContentBlocks {
 						);
 					}
 				);
-
-			}
+			}//end if
 
 			// If GraphQL class doesn't exist, then dependencies cannot be
 			// detected. This likely means the user cloned the repo from Github

--- a/includes/utilities/DomHelpers.php
+++ b/includes/utilities/DomHelpers.php
@@ -24,7 +24,7 @@ final class DOMHelpers {
 		$value = null;
 		$doc   = new Document();
 		$doc->loadHTML( $html );
-		if ('*' == $selector) {
+		if ( '*' == $selector ) {
 			$selector = '*' . '[' . $attribute . ']';
 		}
 		$node    = $doc->find( $selector );


### PR DESCRIPTION
This PR aims to close #51. 

This PR does the following:

- Block.php
- - introduce "get_block_interfaces"
- Registry.php
- - introduce get_block_context_interfaces method, which will populate the $block_interfaces class variable with an array of interfaces per block type and will return a specific array of interfaces given a block name
- - removed the call to `register_graphql_interfaces_to_types()` that was registering interfaces to all block types iteratively.
- - renamed `NodeWith . $post_type . 'Blocks'` to `NodeWith. $post_type . 'EditorBlocks' to keep naming more consistent
- PostTypeBlockInterface.php
- - renamed `NodeWith . $post_type . 'Blocks'` to `NodeWith. $post_type . 'EditorBlocks' to keep naming more consistent
- - renamed `ucfirst( $post_type ) . 'Block'` to `ucfirst( $post_type ) . 'EditorBlock'` to keep naming more consistent
- ran composer phpcs:fix

----

## Before (with main #47 merged)

Loading the Schema in GraphiQL takes 40 seconds:

![CleanShot 2023-04-07 at 15 07 37](https://user-images.githubusercontent.com/1260765/230679650-20ce5da4-d3ae-491d-88eb-094061e39300.png)

Query for posts (not even asking for blocks) takes +10 seconds:

![CleanShot 2023-04-07 at 15 12 52](https://user-images.githubusercontent.com/1260765/230679760-53e63225-5acf-4ef9-81fb-d7458d3caba7.png)

The "Page.editorBlocks" field returns a listOf EditorBlock, but I expect this to be a listOf `PageEditorBlock`

![CleanShot 2023-04-07 at 15 22 03](https://user-images.githubusercontent.com/1260765/230680685-f3e4ad07-69a6-44e9-b918-5c49e8650107.png)

## After (changes from this PR applied)

Loading the Schema in GraphiQL takes 9 seconds:

![CleanShot 2023-04-07 at 15 14 40](https://user-images.githubusercontent.com/1260765/230679918-42ae66a9-5f55-43c2-b160-b1116d573fb1.png)

Executing a query for posts not even asking for blocks) takes 1.7 seconds:

![CleanShot 2023-04-07 at 15 15 47](https://user-images.githubusercontent.com/1260765/230680000-3d513ca1-6eca-44c2-8c6f-361e1a7e13e1.png)

The "Page.editorBlocks" field returns a listOf PageEditorBlock, as expected (instead of listOf EditorBlock)

![CleanShot 2023-04-07 at 15 18 08](https://user-images.githubusercontent.com/1260765/230680432-18297bbd-2a13-4c39-91ef-173f7c364bef.png)

