### PR TITLE
[Merl-862] Add support for Classic Blocks

### DIFF
--- a/includes/Blocks/Block.php
+++ b/includes/Blocks/Block.php
@@ -73,7 +73,7 @@ class Block {
 	 * @return void
 	 */
 	public function register_fields() {     }
-	
+
 
 	private function register_block_type() {
 		$this->register_block_attributes_as_fields();
@@ -203,7 +203,21 @@ class Block {
 	private function resolve_block_attributes( $block, $attribute_name, $attribute_config ) {
 		// Get default value.
 		$default = isset( $attribute_config['default'] ) ? $attribute_config['default'] : null;
-
+		// Case when only source defined: Classic Blocks
+		if ( isset( $attribute_config['source'] ) && ! isset( $attribute_config['selector'] ) ) {
+			$rendered_block = wp_unslash( render_block( $block ) );
+			$value          = null;
+			if ( empty( $rendered_block ) ) {
+				return $value;
+			}
+			switch ( $attribute_config['source'] ) {
+				case 'html':
+					$value = $rendered_block;
+					break;
+			}
+			return $value;
+		}
+		// Case when both selector and source are defined
 		if ( isset( $attribute_config['selector'], $attribute_config['source'] ) ) {
 			$rendered_block = wp_unslash( render_block( $block ) );
 			$value          = null;

--- a/includes/Data/ContentBlocksResolver.php
+++ b/includes/Data/ContentBlocksResolver.php
@@ -54,7 +54,8 @@ final class ContentBlocksResolver {
 		$parsed_blocks = array_filter(
 			$parsed_blocks,
 			function ( $parsed_block ) {
-				return ! empty( trim( $parsed_block['innerHTML'] ) );
+				// Strip empty comments and spaces
+				return ! empty( trim( preg_replace('/<!--(.*)-->/Uis', '', $parsed_block['innerHTML']) ) );
 			},
 			ARRAY_FILTER_USE_BOTH
 		);

--- a/includes/Data/ContentBlocksResolver.php
+++ b/includes/Data/ContentBlocksResolver.php
@@ -50,19 +50,24 @@ final class ContentBlocksResolver {
 		if ( empty( $parsed_blocks ) ) {
 			return array();
 		}
-		// 1st Level filtering of blocks that have no name
+		// 1st Level filtering of blocks that are empty
 		$parsed_blocks = array_filter(
 			$parsed_blocks,
 			function ( $parsed_block ) {
-				return isset( $parsed_block['blockName'] ) && ! empty( $parsed_block['blockName'] );
+				return ! empty( trim( $parsed_block['innerHTML'] ) );
 			},
 			ARRAY_FILTER_USE_BOTH
 		);
 
-		// 1st Level assigning of unique id's
+		// 1st Level assigning of unique id's and missing blockNames
 		$parsed_blocks = array_map(
 			function ( $parsed_block ) {
 				$parsed_block['clientId'] = uniqid();
+				// Since Gutenberg assigns an empty blockName for Classic block
+				// we define the name here
+				if ( empty( $parsed_block['blockName'] ) ) {
+					$parsed_block['blockName'] = 'core/freeform';
+				}
 				return $parsed_block;
 			},
 			$parsed_blocks
@@ -78,7 +83,7 @@ final class ContentBlocksResolver {
 			$parsed_blocks = array_filter(
 				$parsed_blocks,
 				function ( $parsed_block ) use ( $allowed_block_names ) {
-					return isset( $parsed_block['blockName'] ) && in_array( $parsed_block['blockName'], $allowed_block_names, true );
+					return in_array( $parsed_block['blockName'], $allowed_block_names, true );
 				},
 				ARRAY_FILTER_USE_BOTH
 			);
@@ -88,6 +93,8 @@ final class ContentBlocksResolver {
 
 	/**
 	 * Flattens a list blocks into a single array
+	 *
+	 * @param mixed $blocks A list of blocks to flatten.
 	 */
 	private static function flatten_block_list( $blocks ) {
 		$result = array();
@@ -99,6 +106,8 @@ final class ContentBlocksResolver {
 
 	/**
 	 * Flattens a block and it's inner blocks into a single while attaching unique clientId's
+	 *
+	 * @param mixed $block A block.
 	 */
 	private static function flatten_inner_blocks( $block ) {
 		$result            = array();

--- a/includes/Type/InterfaceType/EditorBlockInterface.php
+++ b/includes/Type/InterfaceType/EditorBlockInterface.php
@@ -141,7 +141,7 @@ final class EditorBlockInterface {
 				),
 				'resolveType'     => function ( $block ) use ( $type_registry ) {
 					if ( empty( $block['blockName'] ) ) {
-						$block['blockName'] = 'core/html';
+						$block['blockName'] = 'core/freeform';
 					}
 
 					$type_name = lcfirst( ucwords( $block['blockName'], '/' ) );

--- a/includes/Type/InterfaceType/PostTypeBlockInterface.php
+++ b/includes/Type/InterfaceType/PostTypeBlockInterface.php
@@ -33,7 +33,7 @@ final class PostTypeBlockInterface {
 				),
 				'resolveType' => function ( $block ) use ( $type_registry ) {
 					if ( empty( $block['blockName'] ) ) {
-						$block['blockName'] = 'core/html';
+						$block['blockName'] = 'core/freeform';
 					}
 
 					$type_name = lcfirst( ucwords( $block['blockName'], '/' ) );

--- a/tests/unit/BlockSupportsAnchorTest.php
+++ b/tests/unit/BlockSupportsAnchorTest.php
@@ -23,10 +23,10 @@ final class BlockSupportsAnchorTest extends PluginTestCase {
 						'
                         <!-- wp:paragraph -->
                         <p id="example">Example paragraph with Anchor</p>
-                        <!-- /wp:paragraph --></div>
+                        <!-- /wp:paragraph -->
                         <!-- wp:paragraph -->
                         <p>Example paragraph without Anchor</p>
-                        <!-- /wp:paragraph --></div>
+                        <!-- /wp:paragraph -->
 			        '
 					)
 				),
@@ -109,7 +109,6 @@ final class BlockSupportsAnchorTest extends PluginTestCase {
 		}';
 		$actual = graphql( array( 'query' => $query ) );
 		$node   = $actual['data']['posts']['nodes'][0];
-
 		$this->assertEquals( count( $node['editorBlocks'] ), 2 );
 		$this->assertEquals( $node['editorBlocks'][0]['name'], 'core/paragraph' );
 		$this->assertEquals( $node['editorBlocks'][0]['anchor'], 'example' );

--- a/tests/unit/ContentBlocksResolverTest.php
+++ b/tests/unit/ContentBlocksResolverTest.php
@@ -40,6 +40,9 @@ final class ContentBlocksResolverTest extends PluginTestCase {
 			    <!-- /wp:paragraph --></div>
 			    <!-- /wp:column --></div>
 			    <!-- /wp:columns -->
+
+				<!-- Classic Block -->
+				<p>Hello Classic Block</p>
                 '
 					)
 				),
@@ -58,10 +61,16 @@ final class ContentBlocksResolverTest extends PluginTestCase {
 	public function test_resolve_content_blocks_filters_empty_blocks() {
 		$post_model = new Post( get_post( $this->post_id ) );
 		$actual     = $this->instance->resolve_content_blocks( $post_model, array( 'flat' => true ) );
-
 		// There should return only the non-empty blocks
-		$this->assertEquals( count( $actual ), 5 );
+		$this->assertEquals( count( $actual ), 6 );
 		$this->assertEquals( $actual[0]['blockName'], 'core/columns' );
+	}
+
+	public function test_resolve_content_blocks_resolves_classic_blocks() {
+		$post_model = new Post( get_post( $this->post_id ) );
+		$actual     = $this->instance->resolve_content_blocks( $post_model, array( 'flat' => true ) );
+
+		$this->assertEquals( $actual[5]['blockName'], 'core/freeform' );
 	}
 
 	public function test_resolve_content_blocks_filters_blocks_not_from_allow_list() {


### PR DESCRIPTION
# Description

This PR adds support for querying Classic Blocks. Since those blocks are not stored in the database with a proper name we assign them a name now and resolve them as `CoreFreeForm` returning the contents of the innerHTML as long as the contents are not empty.

# Screenshots
<img width="1161" alt="Screenshot 2023-04-27 at 13 07 58" src="https://user-images.githubusercontent.com/328805/234857313-c4e47345-c21c-4dd5-9405-2a1e42041da9.png">

# Testing
1. Create a Classic block in a post
2. Query for the `content` attribute in editor blocks.
4. Block should resolve as `CoreFreeForm` as plain HTML.