### PR TITLE
Increment `WPGRAPHQL_CONTENT_BLOCKS_VERSION` constant during publishing

### DIFF
--- a/bin/versionPlugin.js
+++ b/bin/versionPlugin.js
@@ -66,7 +66,6 @@ async function bumpStableTag(readmeTxt, version) {
  * @param {String} version    The new version number.
  */
 async function bumpVersionConstant(pluginFile, version) {
-  console.log(version);
   return bumpVersion(
     pluginFile,
     /^\s*\$this->define\(\s*'WPGRAPHQL_CONTENT_BLOCKS_VERSION', '([0-9.]+)/gm,

--- a/bin/versionPlugin.js
+++ b/bin/versionPlugin.js
@@ -6,10 +6,10 @@
  * Ported over from FaustJS
  * @link https://github.com/wpengine/faustjs/blob/canary/scripts/versionPlugin.js
  */
-const fs = require('fs/promises');
-const path = require('path');
+const fs = require("fs/promises");
+const path = require("path");
 
-const readFile = (filename) => fs.readFile(filename, { encoding: 'utf8' });
+const readFile = (filename) => fs.readFile(filename, { encoding: "utf8" });
 const writeFile = fs.writeFile;
 
 /**
@@ -17,16 +17,21 @@ const writeFile = fs.writeFile;
  * including version bumps and readme.txt changelog updates.
  */
 async function versionPlugin() {
-  const pluginPath = path.join(__dirname, '../');
-  const pluginFile = path.join(pluginPath, 'wp-graphql-content-blocks.php');
-  const readmeTxt = path.join(pluginPath, 'readme.txt');
-  const changelog = path.join(pluginPath, 'CHANGELOG.md');
+  const pluginPath = path.join(__dirname, "../");
+  const pluginFile = path.join(pluginPath, "wp-graphql-content-blocks.php");
+  const readmeTxt = path.join(pluginPath, "readme.txt");
+  const changelog = path.join(pluginPath, "CHANGELOG.md");
+  const constantsFile = path.join(
+    pluginPath,
+    "includes/WPGraphQLContentBlocks.php"
+  );
 
   const version = await getNewVersion(pluginPath);
 
   if (version) {
     bumpPluginHeader(pluginFile, version);
     await bumpStableTag(readmeTxt, version);
+    await bumpVersionConstant(constantsFile, version);
     generateReadmeChangelog(readmeTxt, changelog);
   }
 }
@@ -52,6 +57,21 @@ async function bumpPluginHeader(pluginFile, version) {
  */
 async function bumpStableTag(readmeTxt, version) {
   return bumpVersion(readmeTxt, /^Stable tag:\s*([0-9.]+)$/gm, version);
+}
+
+/**
+ * Updates the version constant found in the WPGraphQLContentBlocks.php file.
+ *
+ * @param {String} pluginFile Full path to a file containing PHP constants.
+ * @param {String} version    The new version number.
+ */
+async function bumpVersionConstant(pluginFile, version) {
+  console.log(version);
+  return bumpVersion(
+    pluginFile,
+    /^\s*\$this->define\(\s*'WPGRAPHQL_CONTENT_BLOCKS_VERSION', '([0-9.]+)/gm,
+    version
+  );
 }
 
 /**
@@ -99,7 +119,7 @@ async function bumpVersion(file, regex, version) {
  * @returns The version number string found in the plugin's package.json.
  */
 async function getNewVersion(pluginPath) {
-  const packageJsonFile = path.join(pluginPath, 'package.json');
+  const packageJsonFile = path.join(pluginPath, "package.json");
 
   try {
     let packageJson = await readFile(packageJsonFile);
@@ -129,8 +149,8 @@ async function generateReadmeChangelog(readmeTxtFile, changelog) {
     changelog = await readFile(changelog);
 
     changelog = changelog.replace(
-      '# WPGraphQL Content Blocks',
-      '== Changelog =='
+      "# WPGraphQL Content Blocks",
+      "== Changelog =="
     );
 
     // split the contents by new line
@@ -141,12 +161,12 @@ async function generateReadmeChangelog(readmeTxtFile, changelog) {
     // print all lines in current version
     changelogLines.every((line) => {
       // Version numbers in CHANGELOG.md are h2
-      if (line.startsWith('## ')) {
+      if (line.startsWith("## ")) {
         if (versionCount == 3) {
           return false;
         }
         // Format version number for WordPress
-        line = line.replace('## ', '= ') + ' =';
+        line = line.replace("## ", "= ") + " =";
         versionCount++;
       }
 
@@ -157,10 +177,11 @@ async function generateReadmeChangelog(readmeTxtFile, changelog) {
 
     changelog = processedLines.join("\n");
 
-    const changelogStart = readmeTxt.indexOf('== Changelog ==');
+    const changelogStart = readmeTxt.indexOf("== Changelog ==");
 
     output = readmeTxt.substring(0, changelogStart) + changelog;
-    output += "\n[View the full changelog](https://github.com/wpengine/wp-graphql-content-blocks/blob/main/CHANGELOG.md)";
+    output +=
+      "\n[View the full changelog](https://github.com/wpengine/wp-graphql-content-blocks/blob/main/CHANGELOG.md)";
 
     return writeFile(readmeTxtFile, output);
   } catch (e) {

--- a/includes/WPGraphQLContentBlocks.php
+++ b/includes/WPGraphQLContentBlocks.php
@@ -71,7 +71,7 @@ final class WPGraphQLContentBlocks {
 		$main_file_path = dirname( __DIR__ ) . '/wp-graphql.php';
 
 		// Plugin version.
-		$this->define( 'WPGRAPHQL_CONTENT_BLOCKS_VERSION', '0.0.1' );
+		$this->define( 'WPGRAPHQL_CONTENT_BLOCKS_VERSION', '0.2.0' );
 		// Plugin Folder Path.
 		$this->define( 'WPGRAPHQL_CONTENT_BLOCKS_PLUGIN_DIR', plugin_dir_path( $main_file_path ) );
 		// Plugin Root File.


### PR DESCRIPTION
## Description

This PR increments the `WPGRAPHQL_CONTENT_BLOCKS_VERSION` constant during changesets publishing.

## Testing
1. Checkout this PR
2. Run `npm run version`
3. See the `WPGRAPHQL_CONTENT_BLOCKS_VERSION` constant gets updated along side all the other updates from the `versionPlugin.js` file.