### PR TITLE
Bug: inner blocks "anchor" field being applied to parent block resulting in duplicates

### DIFF
--- a/.changeset/quiet-insects-mate.md
+++ b/.changeset/quiet-insects-mate.md
@@ -1,0 +1,5 @@
+---
+"@wpengine/wp-graphql-content-blocks": patch
+---
+
+Bug Fix: inner blocks "anchor" field being applied to parent block resulting in duplicates

--- a/includes/Field/BlockSupports/Anchor.php
+++ b/includes/Field/BlockSupports/Anchor.php
@@ -31,20 +31,12 @@ class Anchor {
 							'type'        => 'string',
 							'description' => __( 'The anchor field for the block.', 'wp-graphql-content-blocks' ),
 							'resolve'     => function ( $block ) {
-								$attribute_config = array(
-									'type'      => 'string',
-									'source'    => 'attribute',
-									'attribute' => 'id',
-									'selector'  => '*',
-								);
-
-								$rendered_block   = wp_unslash( $block['innerHTML'] );
-
+								$rendered_block   = wp_unslash( render_block( $block ) );
 								$value            = null;
 								if ( empty( $rendered_block ) ) {
 									return $value;
 								}
-								$value = DOMHelpers::parseAttribute( $rendered_block, $attribute_config['selector'], $attribute_config['attribute'], null );
+								$value = DOMHelpers::parseFirstNodeAttribute( $rendered_block, 'id' );
 								return $value;
 							},
 						),

--- a/includes/Field/BlockSupports/Anchor.php
+++ b/includes/Field/BlockSupports/Anchor.php
@@ -37,7 +37,9 @@ class Anchor {
 									'attribute' => 'id',
 									'selector'  => '*',
 								);
-								$rendered_block   = wp_unslash( render_block( $block ) );
+
+								$rendered_block   = wp_unslash( $block['innerHTML'] );
+
 								$value            = null;
 								if ( empty( $rendered_block ) ) {
 									return $value;

--- a/includes/utilities/DomHelpers.php
+++ b/includes/utilities/DomHelpers.php
@@ -43,8 +43,12 @@ final class DOMHelpers {
 	 */
 	public static function parseFirstNodeAttribute( $html, $attribute ) {
 		$value = null;
-		$doc   = new Document( $html );
-		$elem  = $doc->find( '*' )[2];
+		if ( trim( empty( $html ) ) ) {
+			return $value;
+		}
+		$doc = new Document( $html );
+		// <html><body>$html</body></html>
+		$elem = $doc->find( '*' )[2];
 		if ( $elem ) {
 			$value = $elem->getAttribute( $attribute );
 		}

--- a/includes/utilities/DomHelpers.php
+++ b/includes/utilities/DomHelpers.php
@@ -34,6 +34,25 @@ final class DOMHelpers {
 	}
 
 	/**
+	 * Parses the given HTML string to extract the specified attribute selector of the first node.
+	 *
+	 * @param string $html The HTML string to parse.
+	 * @param string $attribute The attribute to extract of the first node.
+	 *
+	 * @return string|null extracted attribute
+	 */
+	public static function parseFirstNodeAttribute( $html, $attribute ) {
+		$value = null;
+		$doc   = new Document( $html );
+		$elem  = $doc->find( '*' )[2];
+		if ( $elem ) {
+			$value = $elem->getAttribute( $attribute );
+		}
+
+		return $value;
+	}
+
+	/**
 	 * Parses the given HTML string to extract the innerHTML contents.
 	 *
 	 * @param string  $html The HTML string to parse.
@@ -53,16 +72,16 @@ final class DOMHelpers {
 		}
 		return $inner_html;
 	}
-	
+
 	/**
 	 * Parses the given HTML string and extracts the specified elements.
-	 * 
+	 *
 	 * @param string $html The HTML string to parse.
 	 * @param string $element The element (selector) to extract.
-	 * 
+	 *
 	 * @return string|null the HTML string of the extracted elements
 	 */
-	public static function getElementsFromHTML($html, $element) {
+	public static function getElementsFromHTML( $html, $element ) {
 		$doc = new Document();
 		$doc->loadHTML( $html );
 		$elements = $doc->find( $element );
@@ -79,18 +98,18 @@ final class DOMHelpers {
 	/**
 	 * Gets the text content of a given selector. If multiple selectors exist,
 	 * the first result will be used.
-	 * 
+	 *
 	 * @param string $html The HTML string to parse.
 	 * @param string $selector The selector to get the text content from.
-	 * 
+	 *
 	 * @return string|null The text content of the selector if found.
 	 */
-	public static function getTextFromSelector($html, $selector) {
+	public static function getTextFromSelector( $html, $selector ) {
 		$doc = new Document();
 		$doc->loadHTML( $html );
 		$nodes = $doc->find( $selector );
 
-		if( count( $nodes ) === 0 ) {
+		if ( count( $nodes ) === 0 ) {
 			return null;
 		}
 

--- a/tests/unit/BlockSupportsAnchorTest.php
+++ b/tests/unit/BlockSupportsAnchorTest.php
@@ -27,6 +27,13 @@ final class BlockSupportsAnchorTest extends PluginTestCase {
                         <!-- wp:paragraph -->
                         <p>Example paragraph without Anchor</p>
                         <!-- /wp:paragraph -->
+
+						<!-- wp:group -->
+						<div class="wp-block-group">
+							<!-- wp:paragraph -->
+							<p id="example-inner">Example inner block</p>
+							<!-- /wp:paragraph -->
+						<!-- /wp:group -->				
 			        '
 					)
 				),
@@ -109,10 +116,18 @@ final class BlockSupportsAnchorTest extends PluginTestCase {
 		}';
 		$actual = graphql( array( 'query' => $query ) );
 		$node   = $actual['data']['posts']['nodes'][0];
-		$this->assertEquals( count( $node['editorBlocks'] ), 2 );
+
+		$this->assertEquals( count( $node['editorBlocks'] ), 4 );
 		$this->assertEquals( $node['editorBlocks'][0]['name'], 'core/paragraph' );
 		$this->assertEquals( $node['editorBlocks'][0]['anchor'], 'example' );
+
 		$this->assertEquals( $node['editorBlocks'][1]['name'], 'core/paragraph' );
 		$this->assertNull( $node['editorBlocks'][1]['anchor'] );
+
+		$this->assertEquals( $node['editorBlocks'][2]['name'], 'core/group' );
+		$this->assertNull( $node['editorBlocks'][2]['anchor'] );
+
+		$this->assertEquals( $node['editorBlocks'][3]['name'], 'core/paragraph' );
+		$this->assertEquals( $node['editorBlocks'][3]['anchor'], 'example-inner' );
 	}
 }


### PR DESCRIPTION
# Description

Bug fix for https://github.com/wpengine/wp-graphql-content-blocks/issues/62

Uses a special case for parsing `Anchor` fields. Instead of searching the whole block HTML we search for the first node id attribute.