### PR TITLE
Feat: Use render_block instead of innerHTML

### DIFF
--- a/includes/Data/ContentBlocksResolver.php
+++ b/includes/Data/ContentBlocksResolver.php
@@ -55,7 +55,7 @@ final class ContentBlocksResolver {
 			$parsed_blocks,
 			function ( $parsed_block ) {
 				// Strip empty comments and spaces
-				return ! empty( trim( preg_replace('/<!--(.*)-->/Uis', '', $parsed_block['innerHTML']) ) );
+				return ! empty( trim( preg_replace( '/<!--(.*)-->/Uis', '', render_block( $parsed_block ) ) ) );
 			},
 			ARRAY_FILTER_USE_BOTH
 		);


### PR DESCRIPTION
# Description
This PR changes the filter blocks function to use `render_block` instead of `innerHTML` when filtering the block contents. This is to ensure that the block gets is rendered with hooks and actions first before filtered out.

# Context
Based on this comment: https://github.com/wpengine/wp-graphql-content-blocks/issues/40#issuecomment-1534964588

