### PR TITLE
tests: fix Unit test autoloading and lint

### DIFF
--- a/.changeset/flat-buttons-shake.md
+++ b/.changeset/flat-buttons-shake.md
@@ -1,0 +1,5 @@
+---
+"@wpengine/wp-graphql-content-blocks": patch
+---
+
+tests: Fix `RegistryTestCase` autoloading and lint `DomHelperTest`

--- a/tests/unit/DOMHelpersTest.php
+++ b/tests/unit/DOMHelpersTest.php
@@ -43,28 +43,28 @@ final class DOMHelpersTest extends PluginTestCase {
 	}
 
 	public function testGetElementsFromHTML(): void {
-		$html = '<blockquote><p>First paragraph</p><div>My div</div><p>Second paragraph</p></blockquote>';
-		$element_selector = 'p';
+		$html                 = '<blockquote><p>First paragraph</p><div>My div</div><p>Second paragraph</p></blockquote>';
+		$element_selector     = 'p';
 		$no_existant_selector = 'span';
 
-		$this->assertEquals( DOMHelpers::getElementsFromHTML( $html, $element_selector), '<p>First paragraph</p><p>Second paragraph</p>' );
-		$this->assertEmpty( DOMHelpers::getElementsFromHTML( $html, $no_existant_selector) );
+		$this->assertEquals( DOMHelpers::getElementsFromHTML( $html, $element_selector ), '<p>First paragraph</p><p>Second paragraph</p>' );
+		$this->assertEmpty( DOMHelpers::getElementsFromHTML( $html, $no_existant_selector ) );
 	}
 
 	public function getTextFromSelector(): void {
 		$html = '<blockquote><p>First paragraph</p><div>My div</div><p>Second paragraph</p></blockquote>';
 
-		$blockquote_element = 'blockquote';
-		$p_element = 'p';
-		$div_element = 'div';
+		$blockquote_element   = 'blockquote';
+		$p_element            = 'p';
+		$div_element          = 'div';
 		$no_existant_selector = 'span';
 
 		// getTextFromSelector should get all text (even descendents) according to "textContent"
 		// https://developer.mozilla.org/en-US/docs/Web/API/Node/textContent
-		$this->assertEquals( DOMHelpers::getTextFromSelector($html, $blockquote_element), 'First paragraphMy divSecond paragraph' );
-		
-		$this->assertEquals( DOMHelpers::getTextFromSelector($html, $p_element), 'First paragraph' );
-		$this->assertEquals( DOMHelpers::getTextFromSelector($html, $div_element), 'My div' );
+		$this->assertEquals( DOMHelpers::getTextFromSelector( $html, $blockquote_element ), 'First paragraphMy divSecond paragraph' );
+
+		$this->assertEquals( DOMHelpers::getTextFromSelector( $html, $p_element ), 'First paragraph' );
+		$this->assertEquals( DOMHelpers::getTextFromSelector( $html, $div_element ), 'My div' );
 		$this->assertEmpty( DOMHelpers::getElementsFromHTML( $html, $no_existant_selector ) );
 	}
 }

--- a/tests/unit/RegistryTestCase.php
+++ b/tests/unit/RegistryTestCase.php
@@ -4,7 +4,7 @@ namespace WPGraphQL\ContentBlocks\Unit;
 
 use \WPGraphQL\ContentBlocks\Registry\Registry;
 
-final class RegistryTest extends PluginTestCase {
+final class RegistryTestCase extends PluginTestCase {
 
 	public $instance;
 


### PR DESCRIPTION
This PR

1. Renames `WPGraphQL\ContentBlocks\Unit\RegistryTest` to `RegistryTestCase` to comply with PSR-4 autoloading.
2. Lints `DOMHelperTest` _using PHPCBF only_.

**Note:** The `composer.lock` file was _not_ regenerated, since I don't know what version of PHP ya'll are using to compile (to be addressed in a separate PR).

IDK what happened to the PR template, but 
- [x] I have signed the contributor agreement in the past

![image](https://github.com/wpengine/wp-graphql-content-blocks/assets/29322304/b1270ec8-d7eb-490b-91e1-f92c9c71247f)
