### PR TITLE
chore: [PHPCS] disable linting on `/tests`

### DIFF
--- a/.changeset/rude-penguins-develop.md
+++ b/.changeset/rude-penguins-develop.md
@@ -1,0 +1,5 @@
+---
+"@wpengine/wp-graphql-content-blocks": patch
+---
+
+chore: Disable PHPCS linting for `/tests` directory

--- a/.phpcs.xml.dist
+++ b/.phpcs.xml.dist
@@ -7,6 +7,7 @@
 	<!-- Exclude composer vendor directory -->
 	<exclude-pattern>/vendor/</exclude-pattern>
 	<exclude-pattern>/node_modules/</exclude-pattern>
+	<exclude-pattern>/tests/</exclude-pattern>
 
 	<!-- How to scan -->
 	<!-- Usage instructions: https://github.com/squizlabs/PHP_CodeSniffer/wiki/Usage -->


### PR DESCRIPTION
## What

This PR disables `phpcs` linting on the `/tests` directory.

- [x] Yes I signed the contributor agreement.

## Why

WPCS represents WordPress production coding standards. Most of these rules don't apply to the normal PHPUnit (and assumingly future Codeception) patterns, and it seems like unnecessary busywork to ensure they comply with no tangible benefit. It also means contributing tests becomes a `good first issue`, since no knowledge of WordPress/WPGraphQL/WPGraphQLContentBlocks is required.

## Alternatives considered
- We could add a separate `.phpcs.xml.dist` file to the `/tests` directory. This seems unnecessary as per the above.
- We could include them in the default lint, but change `composer phpcs` (and an eventual GH Workflow) to only lint `/includes` and base-directory files. This way the IDE would still hint our ruleset when writing tests, but wouldnt enforce it on production code. I'll leave it up to ya'll to decide whether those unenforced hints are helpful or noise (and happy to contribute the PR to do things this way) 