### PR TITLE
chore: misc PHPCS fixes

### DIFF
--- a/.changeset/cuddly-countries-doubt.md
+++ b/.changeset/cuddly-countries-doubt.md
@@ -1,0 +1,5 @@
+---
+"@wpengine/wp-graphql-content-blocks": patch
+---
+
+dev: Change comparison of `$attribute_config['type']` to use Yoda conditional.

--- a/.changeset/green-bobcats-cover.md
+++ b/.changeset/green-bobcats-cover.md
@@ -1,0 +1,5 @@
+---
+"@wpengine/wp-graphql-content-blocks": patch
+---
+
+dev: Remove unused method params from the block attribute field resolver callback.

--- a/.changeset/hot-files-jump.md
+++ b/.changeset/hot-files-jump.md
@@ -1,0 +1,5 @@
+---
+"@wpengine/wp-graphql-content-blocks": patch
+---
+
+fix: Replace the usage of `'wp-graphql'` text-domain with the correct `'wp-graphql-content-blocks'`.

--- a/.changeset/ten-fishes-breathe.md
+++ b/.changeset/ten-fishes-breathe.md
@@ -1,0 +1,5 @@
+---
+"@wpengine/wp-graphql-content-blocks": patch
+---
+
+fix: Ensure proper string translation, concatenation, and escaping.

--- a/includes/Blocks/Block.php
+++ b/includes/Blocks/Block.php
@@ -151,7 +151,7 @@ class Block {
 
 				$block_attribute_fields[ Utils::format_field_name( $attribute_name ) ] = array(
 					'type'        => $graphql_type,
-					'description' => __( sprintf( 'The "%1$s" field on the "%2$s" block', $attribute_name, $this->type_name ), 'wp-graphql' ),
+					'description' => __( sprintf( 'The "%1$s" field on the "%2$s" block', $attribute_name, $this->type_name ), 'wp-graphql-content-blocks' ),
 					'resolve'     => function ( $block, $args, $context, $info ) use ( $attribute_name, $attribute_config ) {
 						return $this->resolve_block_attributes( $block, $attribute_name, $attribute_config );
 					},

--- a/includes/Blocks/Block.php
+++ b/includes/Blocks/Block.php
@@ -257,7 +257,7 @@ class Block {
 			}//end switch
 
 			// if type is set to integer, get the integer value of the attribute.
-			if ( $attribute_config['type'] === 'integer' ) {
+			if ( 'integer' === $attribute_config['type'] ) {
 				$value = intval( $value );
 			}
 

--- a/includes/Blocks/Block.php
+++ b/includes/Blocks/Block.php
@@ -165,7 +165,7 @@ class Block {
 						$attribute_name,
 						$this->type_name
 					),
-					'resolve'     => function ( $block, $args, $context, $info ) use ( $attribute_name, $attribute_config ) {
+					'resolve'     => function ( $block ) use ( $attribute_name, $attribute_config ) {
 						return $this->resolve_block_attributes( $block, $attribute_name, $attribute_config );
 					},
 				);

--- a/includes/Blocks/Block.php
+++ b/includes/Blocks/Block.php
@@ -94,7 +94,11 @@ class Block {
 			register_graphql_object_type(
 				$block_attribute_type_name,
 				array(
-					'description' => __( 'Attributes of the %s Block Type', 'wp-graphql-content-blocks' ),
+					'description' => sprintf(
+						// translators: %s is the block type name.
+						__( 'Attributes of the %s Block Type', 'wp-graphql-content-blocks' ),
+						$this->type_name
+					),
 					'fields'      => $block_attribute_fields,
 				)
 			);
@@ -104,7 +108,11 @@ class Block {
 				'attributes',
 				array(
 					'type'        => $block_attribute_type_name,
-					'description' => __( 'Attributes of the %s Block Type', 'wp-graphql-content-blocks' ),
+					'description' => sprintf(
+						// translators: %s is the block type name.
+						__( 'Attributes of the %s Block Type', 'wp-graphql-content-blocks' ),
+						$this->type_name
+					),
 					'resolve'     => function ( $block ) {
 						return $block;
 					},
@@ -151,7 +159,12 @@ class Block {
 
 				$block_attribute_fields[ Utils::format_field_name( $attribute_name ) ] = array(
 					'type'        => $graphql_type,
-					'description' => __( sprintf( 'The "%1$s" field on the "%2$s" block', $attribute_name, $this->type_name ), 'wp-graphql-content-blocks' ),
+					'description' => sprintf(
+						// translators: %1$s is the attribute name, %2$s is the block name.
+						__( 'The "%1$s" field on the "%2$s" block', 'wp-graphql-content-blocks' ),
+						$attribute_name,
+						$this->type_name
+					),
 					'resolve'     => function ( $block, $args, $context, $info ) use ( $attribute_name, $attribute_config ) {
 						return $this->resolve_block_attributes( $block, $attribute_name, $attribute_config );
 					},

--- a/includes/Type/InterfaceType/PostTypeBlockInterface.php
+++ b/includes/Type/InterfaceType/PostTypeBlockInterface.php
@@ -46,7 +46,11 @@ final class PostTypeBlockInterface {
 		register_graphql_interface_type(
 			'NodeWith' . ucfirst( $post_type ) . 'EditorBlocks',
 			array(
-				'description'     => __( 'Node that has ' . $post_type . ' content blocks associated with it', 'wp-graphql-content-blocks' ),
+				'description'     => sprintf(
+					// translators: %s is the post type.
+					__( 'Node that has %s content blocks associated with it', 'wp-graphql-content-blocks' ),
+					$post_type
+				),
 				'eagerlyLoadType' => true,
 				'interfaces'      => array( 'NodeWithEditorBlocks' ),
 				'fields'          => array(
@@ -59,7 +63,11 @@ final class PostTypeBlockInterface {
 								'type' => 'Boolean',
 							),
 						),
-						'description' => __( 'List of ' . $post_type . ' editor blocks', 'wp-graphql-content-blocks' ),
+						'description' => sprintf(
+							// translators: %s is the post type.
+							__( 'List of %s editor blocks', 'wp-graphql-content-blocks' ),
+							$post_type
+						),
 						'resolve'     => function ( $node, $args ) use ( $block_names ) {
 							return ContentBlocksResolver::resolve_content_blocks( $node, $args, $block_names );
 						},

--- a/includes/WPGraphQLContentBlocks.php
+++ b/includes/WPGraphQLContentBlocks.php
@@ -119,7 +119,7 @@ final class WPGraphQLContentBlocks {
 							'<div class="notice notice-error">' .
 								'<p>%s</p>' .
 							'</div>',
-							wp_kses_post( 'WPGraphQL Content Blocks appears to have been installed without it\'s dependencies. If you meant to download the source code, you can run `composer install` to install dependencies. If you are looking for the production version of the plugin, you can download it from the <a target="_blank" href="https://github.com/wpengine/wp-graphql-content-blocks/releases">GitHub Releases tab.</a>', 'wp-graphql-content-blocks' )
+							wp_kses_post( 'WPGraphQL Content Blocks appears to have been installed without its dependencies. If you meant to download the source code, you can run `composer install` to install dependencies. If you are looking for the production version of the plugin, you can download it from the <a target="_blank" href="https://github.com/wpengine/wp-graphql-content-blocks/releases">GitHub Releases tab.</a>', 'wp-graphql-content-blocks' )
 						);
 					}
 				);

--- a/includes/WPGraphQLContentBlocks.php
+++ b/includes/WPGraphQLContentBlocks.php
@@ -45,7 +45,7 @@ final class WPGraphQLContentBlocks {
 	 */
 	public function __clone() {
 		// Cloning instances of the class is forbidden.
-		_doing_it_wrong( __FUNCTION__, esc_html__( 'The WPGraphQLContentBlocks class should not be cloned.', 'wp-graphql' ), '0.0.1' );
+		_doing_it_wrong( __FUNCTION__, esc_html__( 'The WPGraphQLContentBlocks class should not be cloned.', 'wp-graphql-content-blocks' ), '0.0.1' );
 	}
 
 	/**
@@ -56,7 +56,7 @@ final class WPGraphQLContentBlocks {
 	 */
 	public function __wakeup() {
 		// De-serializing instances of the class is forbidden.
-		_doing_it_wrong( __FUNCTION__, esc_html__( 'De-serializing instances of the WPGraphQLContentBlocks class is not allowed', 'wp-graphql' ), '0.0.1' );
+		_doing_it_wrong( __FUNCTION__, esc_html__( 'De-serializing instances of the WPGraphQLContentBlocks class is not allowed', 'wp-graphql-content-blocks' ), '0.0.1' );
 	}
 
 	/**
@@ -112,7 +112,7 @@ final class WPGraphQLContentBlocks {
 							'<div class="notice notice-error">' .
 							'<p>%s</p>' .
 							'</div>',
-							__( 'WPGraphQL Content Blocks appears to have been installed without it\'s dependencies. If you meant to download the source code, you can run `composer install` to install dependencies. If you are looking for the production version of the plugin, you can download it from the <a target="_blank" href="https://github.com/wpengine/wp-graphql-content-blocks/releases">GitHub Releases tab.</a>', 'wp-graphql' )
+							__( 'WPGraphQL Content Blocks appears to have been installed without it\'s dependencies. If you meant to download the source code, you can run `composer install` to install dependencies. If you are looking for the production version of the plugin, you can download it from the <a target="_blank" href="https://github.com/wpengine/wp-graphql-content-blocks/releases">GitHub Releases tab.</a>', 'wp-graphql-content-blocks' )
 						);
 					}
 				);
@@ -133,7 +133,7 @@ final class WPGraphQLContentBlocks {
 							'<div class="notice notice-error is-dismissible">' .
 								'<p>%s</p>' .
 								'</div>',
-							__( 'WPGraphQL Content Blocks will not work without WPGraphQL installed and active.', 'wp-graphql' )
+							__( 'WPGraphQL Content Blocks will not work without WPGraphQL installed and active.', 'wp-graphql-content-blocks' )
 						);
 					}
 				);

--- a/includes/WPGraphQLContentBlocks.php
+++ b/includes/WPGraphQLContentBlocks.php
@@ -110,9 +110,9 @@ final class WPGraphQLContentBlocks {
 
 						echo sprintf(
 							'<div class="notice notice-error">' .
-							'<p>%s</p>' .
+								'<p>%s</p>' .
 							'</div>',
-							__( 'WPGraphQL Content Blocks appears to have been installed without it\'s dependencies. If you meant to download the source code, you can run `composer install` to install dependencies. If you are looking for the production version of the plugin, you can download it from the <a target="_blank" href="https://github.com/wpengine/wp-graphql-content-blocks/releases">GitHub Releases tab.</a>', 'wp-graphql-content-blocks' )
+							esc_html__( 'WPGraphQL Content Blocks appears to have been installed without it\'s dependencies. If you meant to download the source code, you can run `composer install` to install dependencies. If you are looking for the production version of the plugin, you can download it from the <a target="_blank" href="https://github.com/wpengine/wp-graphql-content-blocks/releases">GitHub Releases tab.</a>', 'wp-graphql-content-blocks' )
 						);
 					}
 				);
@@ -132,8 +132,8 @@ final class WPGraphQLContentBlocks {
 						echo sprintf(
 							'<div class="notice notice-error is-dismissible">' .
 								'<p>%s</p>' .
-								'</div>',
-							__( 'WPGraphQL Content Blocks will not work without WPGraphQL installed and active.', 'wp-graphql-content-blocks' )
+							'</div>',
+							esc_html__( 'WPGraphQL Content Blocks will not work without WPGraphQL installed and active.', 'wp-graphql-content-blocks' )
 						);
 					}
 				);

--- a/includes/WPGraphQLContentBlocks.php
+++ b/includes/WPGraphQLContentBlocks.php
@@ -119,7 +119,7 @@ final class WPGraphQLContentBlocks {
 							'<div class="notice notice-error">' .
 								'<p>%s</p>' .
 							'</div>',
-							esc_html__( 'WPGraphQL Content Blocks appears to have been installed without it\'s dependencies. If you meant to download the source code, you can run `composer install` to install dependencies. If you are looking for the production version of the plugin, you can download it from the <a target="_blank" href="https://github.com/wpengine/wp-graphql-content-blocks/releases">GitHub Releases tab.</a>', 'wp-graphql-content-blocks' )
+							wp_kses_post( 'WPGraphQL Content Blocks appears to have been installed without it\'s dependencies. If you meant to download the source code, you can run `composer install` to install dependencies. If you are looking for the production version of the plugin, you can download it from the <a target="_blank" href="https://github.com/wpengine/wp-graphql-content-blocks/releases">GitHub Releases tab.</a>', 'wp-graphql-content-blocks' )
 						);
 					}
 				);

--- a/includes/utilities/DomHelpers.php
+++ b/includes/utilities/DomHelpers.php
@@ -25,7 +25,7 @@ final class DOMHelpers {
 		$doc   = new Document();
 		$doc->loadHTML( $html );
 		if ( '*' == $selector ) {
-			$selector = '*' . '[' . $attribute . ']';
+			$selector = '*[' . $attribute . ']';
 		}
 		$node    = $doc->find( $selector );
 		$default = isset( $default ) ? $default : null;


### PR DESCRIPTION
This PR addresses 17 failing PHPCS smells.

While production code has been updated, *no user-facing / api functionality has been changed*. 

- [x] Yes I signed the contribution agreement.

## Details
- Fixed the usage of `wp-graphql` as a text domain when it should be `wp-graphql-content-blocks`
- Fixed a handful of issues regarding string translation (improper / missing use of `sprintf`, non-escaped strings, unnecessary interpolation).
- Removed the unused params passed from the block attribute field resolver to our anonymous callback.
- Fixed a yoda conditional.