### PR TITLE
fix: [PHPCS] use `wp_rand()` instead of `rand()`

### DIFF
--- a/.changeset/three-ways-dress.md
+++ b/.changeset/three-ways-dress.md
@@ -1,0 +1,5 @@
+---
+"@wpengine/wp-graphql-content-blocks": patch
+---
+
+fix: Use `wp_rand()` instead of `rand()`.

--- a/includes/utilities/WPHelpers.php
+++ b/includes/utilities/WPHelpers.php
@@ -68,7 +68,7 @@ final class WPHelpers {
 		$post->post_status    = '';
 		$post->comment_status = 'closed';
 		$post->ping_status    = 'closed';
-		$post->post_name      = 'fake-post-' . rand( 1, 99999 );
+		$post->post_name      = 'fake-post-' . wp_rand( 1, 99999 );
 
 		$post->post_type      = $post_type;
 		$post->filter         = 'raw';


### PR DESCRIPTION
This PR replaces the usage of `rand()` with `wp_rand()` , per the project's PHPCS ruleset.

Since it's anyways being used for a rubbish name property, this should have no actual impact on usage.