### PR TITLE
fix: [PHPCS] use strict comparison for `$selector`

### DIFF
--- a/.changeset/wise-boxes-teach.md
+++ b/.changeset/wise-boxes-teach.md
@@ -1,0 +1,5 @@
+---
+"@wpengine/wp-graphql-content-blocks": patch
+---
+
+fix: Use strict string comparison when parsing the attribute selector.

--- a/includes/utilities/DomHelpers.php
+++ b/includes/utilities/DomHelpers.php
@@ -24,7 +24,7 @@ final class DOMHelpers {
 		$value = null;
 		$doc   = new Document();
 		$doc->loadHTML( $html );
-		if ( '*' == $selector ) {
+		if ( '*' === $selector ) {
 			$selector = '*' . '[' . $attribute . ']';
 		}
 		$node    = $doc->find( $selector );


### PR DESCRIPTION
This PR replaces the usage of a loose comparator (`==`) with a strict one (`===`), when checking the `$selector` value in `DOMHelpers::parseAttribute()`.

Since there is no loose value that matches `'*'`, this is a code smell that has no effect on the actual plugin logic.

**Note:** The [other use of a loose comparison](https://github.com/wpengine/wp-graphql-content-blocks/blob/946c80f77e666abcd9626cff78d770aacfbb37fc/includes/Data/ContentBlocksResolver.php#L78) picked up by PHPCS has been left alone, since `true == 'true'`)