### PR TITLE
dev: [PHPCS] rename `OnInit()` methods to `init()`

### DIFF
--- a/.changeset/quiet-boxes-relax.md
+++ b/.changeset/quiet-boxes-relax.md
@@ -1,0 +1,5 @@
+---
+"@wpengine/wp-graphql-content-blocks": patch
+---
+
+dev: Rename `WPGraphQL\ContentBlocks\Registry::OnInit()` and `WPGraphQL\ContentBlocks\Type\Scalar::OnInit()` methods to `::init()` to comply with WPCS ruleset.

--- a/includes/Registry/Registry.php
+++ b/includes/Registry/Registry.php
@@ -52,10 +52,8 @@ final class Registry {
 
 	/**
 	 * Registry init procedure.
-	 *
-	 * @throws Exception
 	 */
-	public function OnInit() {
+	public function init(): void {
 		$this->register_interface_types();
 		$this->register_scalar_types();
 		$this->register_block_types();
@@ -193,7 +191,7 @@ final class Registry {
 	 * @return void
 	 */
 	protected function register_scalar_types() {
-		( new Scalar() )->OnInit();
+		( new Scalar() )->init();
 	}
 
 	/**

--- a/includes/Type/Scalar/Scalar.php
+++ b/includes/Type/Scalar/Scalar.php
@@ -11,7 +11,7 @@ final class Scalar {
 	/**
 	 * Scalar init procedure.
 	 */
-	public function OnInit() {
+	public function init() {
 		register_graphql_scalar(
 			'BlockAttributesObject',
 			array(

--- a/includes/WPGraphQLContentBlocks.php
+++ b/includes/WPGraphQLContentBlocks.php
@@ -158,7 +158,7 @@ final class WPGraphQLContentBlocks {
 
 	public function init_block_editor_registry( \WPGraphQL\Registry\TypeRegistry $type_registry ) {
 		$block_editor_registry = new \WPGraphQL\ContentBlocks\Registry\Registry( $type_registry, \WP_Block_Type_Registry::get_instance() );
-		$block_editor_registry->onInit();
+		$block_editor_registry->init();
 	}
 
 	/**

--- a/tests/unit/RegistryTestCase.php
+++ b/tests/unit/RegistryTestCase.php
@@ -4,8 +4,10 @@ namespace WPGraphQL\ContentBlocks\Unit;
 
 use \WPGraphQL\ContentBlocks\Registry\Registry;
 
-final class RegistryTest extends PluginTestCase {
-
+final class RegistryTestCase extends PluginTestCase {
+	/**
+	 * @var ?\WPGraphQL\ContentBlocks\Registry\Registry
+	 */
 	public $instance;
 
 	public function setUp(): void {
@@ -36,13 +38,13 @@ final class RegistryTest extends PluginTestCase {
 			__type(name: $name) {
 				interfaces {
 					name
-                    description
+					description
 				}
 			}
 		}
 		';
 
-		$this->instance->OnInit();
+		$this->instance->init();
 
 		// Verify the response contains what we put in cache
 		$response           = graphql(
@@ -89,7 +91,7 @@ final class RegistryTest extends PluginTestCase {
 				description
 				interfaces {
 					name
-                    description
+					description
 				}
 				possibleTypes {
 					name
@@ -98,7 +100,7 @@ final class RegistryTest extends PluginTestCase {
 		}
 		';
 
-		$this->instance->OnInit();
+		$this->instance->init();
 
 		// Verify Post meta
 		$response           = graphql(


### PR DESCRIPTION
This PR renames the `WPGraphQL\ContentBlocks\Registry::OnInit()` and the `WPGraphQL\ContentBlocks\Type\Scalar::OnInit()` methods to `::init()` in order to comply with WPCS.

(Personally, I think the entire `Scalar` class should be renamed to `Scalar\BlockAttributesObject` and follow the established ecosystem pattern, but that's a (relatively) larger change with no immediate benefit).