### PR TITLE
dev!: rename `BlockAttributesObject()` to `get_block_attributes_object_type_name()`

### DIFF
--- a/includes/Blocks/Block.php
+++ b/includes/Blocks/Block.php
@@ -141,7 +141,7 @@ class Block {
 						break;
 					case 'array':
 					case 'object':
-						$graphql_type = Scalar::BlockAttributesObject();
+						$graphql_type = Scalar::get_block_attributes_object_type_name();
 						break;
 				}
 

--- a/includes/Type/Scalar/Scalar.php
+++ b/includes/Type/Scalar/Scalar.php
@@ -21,10 +21,11 @@ final class Scalar {
 			)
 		);
 	}
+
 	/**
 	 * Return type name of BlockAttributesObject.
 	 */
-	public static function BlockAttributesObject() {
+	public static function get_block_attributes_object_type_name() {
 		return 'BlockAttributesObject';
 	}
 }


### PR DESCRIPTION
This PR renames the `WPGraphQL\ContentBlocks\Type\Scalar\Scalar::BlockAttributesObject()` method to the snake_cased `get_block_attributes_object_type_name()` to comply with WPCS while still remaining semantic.

**This is a breaking change.**


## Personal opinion
As mentioned in #76 , i'd much rather see *this PR rejected* and the codebase replace `Scalar` with:
```php
namespace WPGraphQL\ContentBlocks\Type\Scalar;
class BlockAttributesObject {
  public static function register();
  public static function get_type_name();
}
```
(since its the same level of 'breaking' for the api), but I'm trying to work within the codebase's existing patterns.