### PR TITLE
dev: [PHPCS] deprecate unused `$context` param on `EditorBlockInterface::get_blocks()`

### DIFF
--- a/.changeset/strong-paws-pump.md
+++ b/.changeset/strong-paws-pump.md
@@ -1,0 +1,5 @@
+---
+"@wpengine/wp-graphql-content-blocks": patch
+---
+
+dev: Deprecate the unused `$context` param on EditorBlockInterface::get_blocks(), and update all internal usage of that method.

--- a/includes/Type/InterfaceType/EditorBlockInterface.php
+++ b/includes/Type/InterfaceType/EditorBlockInterface.php
@@ -25,7 +25,7 @@ final class EditorBlockInterface {
 	 *
 	 * @return \WP_Block_Type|null
 	 */
-	public static function get_block( array $block, #[Deprecated] $context = null ) {
+	public static function get_block( array $block, $context = null ) {
 		if ( null !== $context ) {
 			_deprecated_argument(
 				__METHOD__,

--- a/includes/Type/InterfaceType/EditorBlockInterface.php
+++ b/includes/Type/InterfaceType/EditorBlockInterface.php
@@ -2,7 +2,6 @@
 
 namespace WPGraphQL\ContentBlocks\Type\InterfaceType;
 
-use Exception;
 use WP_Block_Type_Registry;
 use WPGraphQL\AppContext;
 use WPGraphQL\Registry\TypeRegistry;
@@ -16,12 +15,22 @@ use WPGraphQL\ContentBlocks\Data\ContentBlocksResolver;
  */
 final class EditorBlockInterface {
 	/**
-	 * @param array      $block   The block being resolved.
-	 * @param AppContext $context The AppContext.
+	 * Gets the block from the Block Registry.
+	 *
+	 * @param array $block The block being resolved.
+	 * @param null  $context Deprecated.
 	 *
 	 * @return mixed WP_Block_Type|null
 	 */
-	public static function get_block( array $block, AppContext $context ) {
+	public static function get_block( array $block, #[Deprecated] $context = null ) {
+		if ( null !== $context ) {
+			_deprecated_argument(
+				__METHOD__,
+				'@todo',
+				esc_html__( 'The $context argument is no longer used and will be removed in a future version.', 'wp-graphql-content-blocks' )
+			);
+		}
+
 		$registered_blocks = WP_Block_Type_Registry::get_instance()->get_all_registered();
 
 		if ( ! isset( $block['blockName'] ) ) {
@@ -93,22 +102,22 @@ final class EditorBlockInterface {
 					'blockEditorCategoryName' => array(
 						'type'        => 'String',
 						'description' => __( 'The name of the category the Block belongs to', 'wp-graphql-content-blocks' ),
-						'resolve'     => function ( $block, $args, AppContext $context ) {
-							return isset( self::get_block( $block, $context )->category ) ? self::get_block( $block, $context )->category : null;
+						'resolve'     => function ( $block ) {
+							return isset( self::get_block( $block )->category ) ? self::get_block( $block )->category : null;
 						},
 					),
 					'isDynamic'               => array(
 						'type'        => array( 'non_null' => 'Boolean' ),
 						'description' => __( 'Whether the block is Dynamic (server rendered)', 'wp-graphql-content-blocks' ),
-						'resolve'     => function ( $block, $args, AppContext $context ) {
-							return isset( self::get_block( $block, $context )->render_callback ) && ! empty( self::get_block( $block, $context )->render_callback );
+						'resolve'     => function ( $block ) {
+							return isset( self::get_block( $block )->render_callback ) && ! empty( self::get_block( $block )->render_callback );
 						},
 					),
 					'apiVersion'              => array(
 						'type'        => 'Integer',
 						'description' => __( 'The API version of the Gutenberg Block', 'wp-graphql-content-blocks' ),
-						'resolve'     => function ( $block, $args, AppContext $context ) {
-							return isset( self::get_block( $block, $context )->api_version ) && absint( self::get_block( $block, $context )->api_version ) ? absint( self::get_block( $block, $context )->api_version ) : 2;
+						'resolve'     => function ( $block ) {
+							return isset( self::get_block( $block )->api_version ) && absint( self::get_block( $block )->api_version ) ? absint( self::get_block( $block )->api_version ) : 2;
 						},
 					),
 					'innerBlocks'             => array(

--- a/tests/unit/EditorBlockInterfaceTest.php
+++ b/tests/unit/EditorBlockInterfaceTest.php
@@ -6,15 +6,12 @@ use \WPGraphQL\ContentBlocks\Type\InterfaceType\EditorBlockInterface;
 
 final class EditorBlockInterfaceTest extends PluginTestCase {
 
-	public $instance;
 	public function setUp(): void {
 		parent::setUp();
 
 		$settings                                 = get_option( 'graphql_general_settings' );
 		$settings['public_introspection_enabled'] = 'on';
 		update_option( 'graphql_general_settings', $settings );
-
-		$this->instance = new EditorBlockInterface();
 	}
 
 	public function tearDown(): void {
@@ -34,10 +31,9 @@ final class EditorBlockInterfaceTest extends PluginTestCase {
 		$block_does_not_exist = array(
 			'blockName' => 'core/block_does_not_exist',
 		);
-		$context              = \WPGraphQL::get_app_context();
 
-		$this->assertNull( $this->instance->get_block( $block_does_not_exist, $context ) );
-		$this->assertNotNull( $this->instance->get_block( $block_exists, $context ) );
+		$this->assertNull( EditorBlockInterface::get_block( $block_does_not_exist ) );
+		$this->assertNotNull( EditorBlockInterface::get_block( $block_exists ) );
 	}
 
 	/**
@@ -46,12 +42,12 @@ final class EditorBlockInterfaceTest extends PluginTestCase {
 	public function test_register_type() {
 		$queryNodeWithEditorBlocksMeta = '
 		query NodeWithEditorBlocksMeta {
-            __type(name: "NodeWithEditorBlocks") {
-              fields {
-                name
-              }
-            }
-          }
+				__type(name: "NodeWithEditorBlocks") {
+					fields {
+						name
+					}
+				}
+			}
 		';
 
 		// Verify NodeWithEditorBlocks fields registration
@@ -75,12 +71,12 @@ final class EditorBlockInterfaceTest extends PluginTestCase {
 
 		$queryContentBlockMeta = '
 		query ContentBlockMeta {
-            __type(name: "EditorBlock") {
-              fields {
-                name
-              }
-            }
-          }
+				__type(name: "EditorBlock") {
+					fields {
+						name
+					}
+				}
+			}
 		';
 
 		// Verify ContentBlock fields registration


### PR DESCRIPTION
This PR deprecates the unused `$context` param from the `EditorBlockInterface::get_blocks()` method. All internal usage of that method has been updated as well.

Incidentally, the `EditorBlockInterfaceTest` class was also fixed to call that method statically instead of on an instance.

- [x] Yes I signed the contributor agreement