### PR TITLE
chore: bump min PHP version to 7.4

### DIFF
--- a/.changeset/blue-ducks-happen.md
+++ b/.changeset/blue-ducks-happen.md
@@ -1,0 +1,5 @@
+---
+"@wpengine/wp-graphql-content-blocks": patch
+---
+
+chore: bump min PHP version to 7.4

--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
   "prefer-stable": true,
   "minimum-stability": "dev",
   "require": {
-		"php": "^7.2",
+    "php": "^7.4",
     "imangazaliev/didom": "^2.0"
   },
   "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -31,12 +31,12 @@
     "allow-plugins": {
       "dealerdirect/phpcodesniffer-composer-installer": true
     },
-		"platform": {
-			"php": "7.3"
-		},
-		"preferred-install": "dist",
-		"process-timeout": 0,
-		"optimize-autoloader": true
+    "platform": {
+      "php": "7.4"
+    },
+    "preferred-install": "dist",
+    "process-timeout": 0,
+    "optimize-autoloader": true
   },
   "autoload": {
     "psr-4": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "5b52203da82dfff194a1d82757f9cac9",
+    "content-hash": "bd0580e5bd2b21de0d479af4947ffaf3",
     "packages": [
         {
             "name": "imangazaliev/didom",
@@ -2712,7 +2712,7 @@
     },
     "platform-dev": [],
     "platform-overrides": {
-        "php": "7.3"
+        "php": "7.4"
     },
     "plugin-api-version": "2.3.0"
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "5d71cc1237d2a8bf35bb6a3bebe96e95",
+    "content-hash": "5b52203da82dfff194a1d82757f9cac9",
     "packages": [
         {
             "name": "imangazaliev/didom",
@@ -2708,7 +2708,7 @@
     "prefer-stable": true,
     "prefer-lowest": false,
     "platform": {
-        "php": "^7.2"
+        "php": "^7.4"
     },
     "platform-dev": [],
     "platform-overrides": {

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: faustjs, faust, headless, decoupled, gutenberg
 Requires at least: 5.7
 Tested up to: 6.1
 Stable tag: 0.2.1
-Requires PHP: 7.2
+Requires PHP: 7.4
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 

--- a/wp-graphql-content-blocks.php
+++ b/wp-graphql-content-blocks.php
@@ -9,7 +9,7 @@
  * Text Domain: wp-graphql-content-blocks
  * Domain Path: /languages
  * Version: 0.2.1
- * Requires PHP: 7.2
+ * Requires PHP: 7.4
  * Requires at least: 5.7
  *
  * @package WPGraphQL\ContentBlocks


### PR DESCRIPTION
Bumps min required version of PHP to 7.4, to prevent errors like seen in #68. WP would not have allowed the plugin to be activated under those conditions if the plugin header were up to date.

Closes #68 