### PR TITLE
ci: wait until db is ready instead of sleeping fixed amount of time

### DIFF
--- a/.github/workflows/test-plugin.yml
+++ b/.github/workflows/test-plugin.yml
@@ -16,8 +16,11 @@ jobs:
         working-directory: ./
         run: docker-compose up -d
 
-      - name: Sleep 15 seconds
-        run: sleep 15
+      - name: Wait for db
+        run: |
+          while ! mysqladmin ping --host=127.0.0.1 --port=33066 --password=$MYSQL_ROOT_PASSWORD --silent; do
+            sleep 1
+          done
 
       - name: Setup testing framework
         working-directory: ./


### PR DESCRIPTION
Removes the fixed 15 second sleep in favor of using `mysqladmin ping` to detect when the db is ready. Seems to save 5-6 secs per run in my tests, and in theory it would prevent failures if mysql took longer than 15 secs.