### PR TITLE
fix: [PHPStan] actions should return void

### DIFF
--- a/.changeset/good-colts-develop.md
+++ b/.changeset/good-colts-develop.md
@@ -1,0 +1,5 @@
+---
+"@wpengine/wp-graphql-content-blocks": patch
+---
+
+fix: Don't return the `WPGraphQLContentBlocks` instance when initializing the plugin via the `plugins_loaded` action.

--- a/wp-graphql-content-blocks.php
+++ b/wp-graphql-content-blocks.php
@@ -30,14 +30,11 @@ if ( ! function_exists( 'wpgraphql_content_blocks_init' ) ) {
 	/**
 	 * The main function that returns the WPGraphQLContentBlocks class
 	 *
-	 * @since 1.0.0
-	 * @return object|WPGraphQLContentBlocks
+	 * @since 0.0.1
 	 */
-	function wpgraphql_content_blocks_init() {
-		/**
-		 * Return an instance of the action
-		 */
-		return \WPGraphQLContentBlocks::instance();
+	function wpgraphql_content_blocks_init(): void {
+		// Instantiate the plugin class.
+		WPGraphQLContentBlocks::instance();
 	}
 }
 


### PR DESCRIPTION
This PR changes the `wpgraphql_content_blocks_init()` method to return `void`.

**Note:** I _do not_ believe this should be considered a breaking change since the only valid use of that method is on `add_action('plugins_loaded')`.

Once merged, PHPStan Level 0 (#87) will pass and a CI workflow can be added to run `phpstan` to prevent the further introduction of Level 0 errors into the codebase.