### PR TITLE
fix: restore missing `__()` in admin notice

### DIFF
--- a/includes/WPGraphQLContentBlocks.php
+++ b/includes/WPGraphQLContentBlocks.php
@@ -119,7 +119,9 @@ final class WPGraphQLContentBlocks {
 							'<div class="notice notice-error">' .
 								'<p>%s</p>' .
 							'</div>',
-							wp_kses_post( 'WPGraphQL Content Blocks appears to have been installed without its dependencies. If you meant to download the source code, you can run `composer install` to install dependencies. If you are looking for the production version of the plugin, you can download it from the <a target="_blank" href="https://github.com/wpengine/wp-graphql-content-blocks/releases">GitHub Releases tab.</a>', 'wp-graphql-content-blocks' )
+							wp_kses_post(
+								__( 'WPGraphQL Content Blocks appears to have been installed without its dependencies. If you meant to download the source code, you can run `composer install` to install dependencies. If you are looking for the production version of the plugin, you can download it from the <a target="_blank" href="https://github.com/wpengine/wp-graphql-content-blocks/releases">GitHub Releases tab.</a>', 'wp-graphql-content-blocks' )
+							)
 						);
 					}
 				);


### PR DESCRIPTION
This PR fixes a regression in #73 , where `wp_kses_post()` _replaced_ the preexisting `__()` instead of wrapping around it. This restores the `__()` to the string meant to be translated.

No changeset is included, since its part of the same changelog item included #73

Caught by PHPStan Level 1.