### PR TITLE
dev: [PHPStan] remove unused `$type_registry` from `resolveType` callbacks

### DIFF
--- a/.changeset/rare-snakes-return.md
+++ b/.changeset/rare-snakes-return.md
@@ -1,0 +1,5 @@
+---
+"@wpengine/wp-graphql-content-blocks": patch
+---
+
+dev: Remove unnecessary `use( $type_registry )` from Interface 'resolveType' callbacks.

--- a/includes/Registry/Registry.php
+++ b/includes/Registry/Registry.php
@@ -150,7 +150,7 @@ final class Registry {
 	 */
 	protected function register_interface_types(): void {
 		// First register the NodeWithEditorBlocks interface by default
-		EditorBlockInterface::register_type( $this->type_registry );
+		EditorBlockInterface::register_type();
 
 		// Then try to register both NodeWithEditorBlocks and NodeWith[PostType]Blocks per post type
 		$supported_post_types = WPHelpers::get_supported_post_types();
@@ -185,7 +185,7 @@ final class Registry {
 			// If there is a list of supported blocks for current post type
 			if ( is_array( $supported_blocks_for_post_type ) ) {
 				// Register an [PostType]Block type for the blocks using that post type
-				PostTypeBlockInterface::register_type( $type_name, $supported_blocks_for_post_type, $this->type_registry );
+				PostTypeBlockInterface::register_type( $type_name, $supported_blocks_for_post_type );
 
 				// Register the `NodeWith[PostType]Blocks` Interface to the post type
 				register_graphql_interfaces_to_types( array( 'NodeWith' . Utils::format_type_name( $post_type->graphql_single_name ) . 'EditorBlocks' ), array( $type_name ) );
@@ -226,8 +226,8 @@ final class Registry {
 	protected function register_block_type( WP_Block_Type $block ) {
 		$block_name = isset( $block->name ) && ! empty( $block->name ) ? $block->name : 'Core/HTML';
 
-		$type_name = preg_replace( '/\//', '', lcfirst( ucwords( $block_name, '/' ) ) );
-		$type_name = Utils::format_type_name( $type_name );
+		$type_name  = preg_replace( '/\//', '', lcfirst( ucwords( $block_name, '/' ) ) );
+		$type_name  = Utils::format_type_name( $type_name );
 		$class_name = Utils::format_type_name( $type_name );
 		$class_name = '\\WPGraphQL\\ContentBlocks\\Blocks\\' . $class_name;
 

--- a/includes/Type/InterfaceType/EditorBlockInterface.php
+++ b/includes/Type/InterfaceType/EditorBlockInterface.php
@@ -8,8 +8,6 @@
 namespace WPGraphQL\ContentBlocks\Type\InterfaceType;
 
 use WP_Block_Type_Registry;
-use WPGraphQL\AppContext;
-use WPGraphQL\Registry\TypeRegistry;
 use WPGraphQL\Utils\Utils;
 use WPGraphQL\ContentBlocks\Data\ContentBlocksResolver;
 
@@ -49,10 +47,8 @@ final class EditorBlockInterface {
 
 	/**
 	 * Registers the types to WPGraphQL.
-	 *
-	 * @param WPGraphQL\Registry\TypeRegistry $type_registry The TypeRegistry.
 	 */
-	public static function register_type( TypeRegistry $type_registry ) {
+	public static function register_type() {
 		register_graphql_interface_type(
 			'NodeWithEditorBlocks',
 			array(
@@ -151,7 +147,7 @@ final class EditorBlockInterface {
 						},
 					),
 				),
-				'resolveType'     => function ( $block ) use ( $type_registry ) {
+				'resolveType'     => function ( $block ) {
 					if ( empty( $block['blockName'] ) ) {
 						$block['blockName'] = 'core/freeform';
 					}

--- a/includes/Type/InterfaceType/PostTypeBlockInterface.php
+++ b/includes/Type/InterfaceType/PostTypeBlockInterface.php
@@ -7,9 +7,7 @@
 
 namespace WPGraphQL\ContentBlocks\Type\InterfaceType;
 
-use Exception;
 use WPGraphQL\ContentBlocks\Data\ContentBlocksResolver;
-use WPGraphQL\Registry\TypeRegistry;
 use WPGraphQL\Utils\Utils;
 
 /**
@@ -19,11 +17,10 @@ final class PostTypeBlockInterface {
 	/**
 	 * Registers the types to WPGraphQL.
 	 *
-	 * @param string                           $post_type The post type.
-	 * @param string[]                         $block_names The list of allowed block names.
-	 * @param \WPGraphQL\Registry\TypeRegistry $type_registry The TypeRegistry.
+	 * @param string   $post_type The post type.
+	 * @param string[] $block_names The list of allowed block names.
 	 */
-	public static function register_type( string $post_type, $block_names, TypeRegistry $type_registry ) {
+	public static function register_type( string $post_type, $block_names ) {
 		register_graphql_interface_type(
 			ucfirst( $post_type ) . 'EditorBlock',
 			array(
@@ -33,7 +30,7 @@ final class PostTypeBlockInterface {
 						'type' => 'String',
 					),
 				),
-				'resolveType' => function ( $block ) use ( $type_registry ) {
+				'resolveType' => function ( $block ) {
 					if ( empty( $block['blockName'] ) ) {
 						$block['blockName'] = 'core/freeform';
 					}


### PR DESCRIPTION
This PR removes the unused `$type_registry` variable from the `resolveType` callbacks in `EditorPostInterface` and `PostTypeBlockInterface`.

Caught by PHPStan level 1.

**Note:** Technically, `Registry::$type_registry` is now unused and can be removed as well, but IDK what interfaces you have in the docket that may rely on it.