### PR TITLE
chore: [PHPStan] add missing `\` to docblock types

### DIFF
--- a/.changeset/few-seas-happen.md
+++ b/.changeset/few-seas-happen.md
@@ -1,0 +1,5 @@
+---
+"@wpengine/wp-graphql-content-blocks": patch
+---
+
+chore: Add missing `\` to docblock types.

--- a/includes/Blocks/Block.php
+++ b/includes/Blocks/Block.php
@@ -59,8 +59,8 @@ class Block {
 	/**
 	 * Block constructor.
 	 *
-	 * @param \WP_Block_Type                            $block The Block Type.
-	 * @param WPGraphQL\ContentBlocks\Registry\Registry $block_registry The instance of the WPGraphQL block registry.
+	 * @param \WP_Block_Type                             $block The Block Type.
+	 * @param \WPGraphQL\ContentBlocks\Registry\Registry $block_registry The instance of the WPGraphQL block registry.
 	 */
 	public function __construct( WP_Block_Type $block, Registry $block_registry ) {
 		$this->block            = $block;

--- a/includes/Registry/Registry.php
+++ b/includes/Registry/Registry.php
@@ -26,7 +26,7 @@ final class Registry {
 	/**
 	 * The instance of the WPGraphQL type registry.
 	 *
-	 * @var WPGraphQL\Registry\TypeRegistry
+	 * @var \WPGraphQL\Registry\TypeRegistry
 	 */
 	public $type_registry;
 
@@ -54,8 +54,8 @@ final class Registry {
 	/**
 	 * Registry constructor.
 	 *
-	 * @param WPGraphQL\Registry\TypeRegistry $type_registry .
-	 * @param \WP_Block_Type_Registry         $block_type_registry .
+	 * @param \WPGraphQL\Registry\TypeRegistry $type_registry .
+	 * @param \WP_Block_Type_Registry          $block_type_registry .
 	 */
 	public function __construct( TypeRegistry $type_registry, $block_type_registry ) {
 		$this->type_registry       = $type_registry;


### PR DESCRIPTION
This PR adds a missing `\` before docblock types using a namespace, as required by by `phpDoc`.

No production code was changed.

Caught by PHPStan level 2. 