### PR TITLE
fix: [PHPStan] bad return type for `WPHelpers::get_supported_post_types()`

### DIFF
--- a/.changeset/fair-students-move.md
+++ b/.changeset/fair-students-move.md
@@ -1,0 +1,5 @@
+---
+"@wpengine/wp-graphql-content-blocks": patch
+---
+
+fix: Ensure `WPHelpers::get_supported_post_types()` correctly returns `\WP_Post_Type[]`.

--- a/includes/utilities/WPHelpers.php
+++ b/includes/utilities/WPHelpers.php
@@ -18,17 +18,18 @@ final class WPHelpers {
 	/**
 	 * Gets Block Editor supported post types
 	 *
-	 * @return array<string>
+	 * @return \WP_Post_Type[]
 	 */
-	public static function get_supported_post_types() {
+	public static function get_supported_post_types(): array {
 		$supported_post_types = array();
 		// Get Post Types that are set to Show in GraphQL and Show in REST
 		// If it doesn't show in REST, it's not block-editor enabled
 		$block_editor_post_types = \WPGraphQL::get_allowed_post_types( 'objects' );
 
 		if ( empty( $block_editor_post_types ) || ! is_array( $block_editor_post_types ) ) {
-			return;
+			return $supported_post_types;
 		}
+
 		// Iterate over the post types
 		foreach ( $block_editor_post_types as $block_editor_post_type ) {
 			// If the post type doesn't support the editor, it's not block-editor enabled


### PR DESCRIPTION
This PR fixes `WPHelpers::get_supported_post_types()`, so it
a) Correctly hints as an array of `WP_Post_Type` objects.
b) Doesn't return void.

The method signature has changed to include a PHP return type, to help prevent future regressions.

Caught by PHPStan level 2.