### PR TITLE
fix: bad conditional check for empty `$html` in `DOMHelpers::parseFirstNodeAttribute()`

### DIFF
--- a/.changeset/purple-rockets-promise.md
+++ b/.changeset/purple-rockets-promise.md
@@ -1,0 +1,5 @@
+---
+"@wpengine/wp-graphql-content-blocks": patch
+---
+
+fix: Bad check for empty value in `DOMHelpers::parseFirstNodeAttribute()`.

--- a/includes/utilities/DomHelpers.php
+++ b/includes/utilities/DomHelpers.php
@@ -46,9 +46,12 @@ final class DOMHelpers {
 	 */
 	public static function parseFirstNodeAttribute( $html, $attribute ) {
 		$value = null;
-		if ( trim( empty( $html ) ) ) {
+
+		// Bail early if there's no html to parse.
+		if ( empty( trim( $html ) ) ) {
 			return $value;
 		}
+
 		$doc = new Document( $html );
 		// <html><body>$html</body></html>
 		$elem = $doc->find( '*' )[2];


### PR DESCRIPTION
This PR fixes a bad conditional in `DOMHelpers::parseFirstNodeAttribute()`, we want to check if the trimmed string is empty, not trim the `bool` check for whether the untrimmed string is empty.

Caught by PHPStan level 5. 