### PR TITLE
fix: Composer PHP version constraint

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
   "prefer-stable": true,
   "minimum-stability": "dev",
   "require": {
-    "php": "^7.4",
+    "php": ">=7.4",
     "imangazaliev/didom": "^2.0"
   },
   "require-dev": {


### PR DESCRIPTION
Fixes the `PHP` version constraint, so it allows _any_ PHP version `>=` than 7.4, instead of any **7.x** version greater than 7.4.

I leaked this into the codebase in #70 (It wasn't picked up since it only affects `composer require`-ing the plugin, and not running the plugin itself). As this was the intent of #81 no separate changeset is included.

## Before / After (via a Bedrock `composer.json requiring PHP 8.0)
![image](https://github.com/wpengine/wp-graphql-content-blocks/assets/29322304/8041a968-d981-467f-8d48-ac71e3f5691a)
