### PR TITLE
chore: [PHPStan] add missing return types

### DIFF
--- a/.changeset/long-gorillas-rescue.md
+++ b/.changeset/long-gorillas-rescue.md
@@ -1,0 +1,5 @@
+---
+"@wpengine/wp-graphql-content-blocks": patch
+---
+
+chore: Add missing return types to multiple methods.

--- a/includes/Blocks/Block.php
+++ b/includes/Blocks/Block.php
@@ -92,10 +92,8 @@ class Block {
 
 	/**
 	 * Registers the block attributes GraphQL type and adds it as a field on the Block.
-	 *
-	 * @return void
 	 */
-	private function register_block_attributes_as_fields() {
+	private function register_block_attributes_as_fields(): void {
 		if ( isset( $this->additional_block_attributes ) ) {
 			$block_attribute_fields = $this->get_block_attribute_fields( array_merge( $this->block_attributes, $this->additional_block_attributes ) );
 		} else {
@@ -137,7 +135,7 @@ class Block {
 	/**
 	 * Registers fields for the block supports.
 	 */
-	private function register_block_support_fields() {
+	private function register_block_support_fields(): void {
 		Anchor::register( $this->block );
 	}
 
@@ -146,7 +144,7 @@ class Block {
 	 *
 	 * @param array $block_attributes The block attributes.
 	 */
-	private function get_block_attribute_fields( $block_attributes ) {
+	private function get_block_attribute_fields( $block_attributes ): array {
 		$block_attribute_fields = array();
 		if ( isset( $block_attributes ) ) {
 			foreach ( $block_attributes as $attribute_name => $attribute_config ) {

--- a/includes/Data/ContentBlocksResolver.php
+++ b/includes/Data/ContentBlocksResolver.php
@@ -20,7 +20,7 @@ final class ContentBlocksResolver {
 	 * @param array $args GraphQL query args to pass to the connection resolver.
 	 * @param array $allowed_block_names The list of allowed block names to filter.
 	 */
-	public static function resolve_content_blocks( $node, $args, $allowed_block_names = array() ) {
+	public static function resolve_content_blocks( $node, $args, $allowed_block_names = array() ): array {
 		$content = null;
 		if ( $node instanceof Post ) {
 
@@ -98,9 +98,9 @@ final class ContentBlocksResolver {
 	/**
 	 * Flattens a list blocks into a single array
 	 *
-	 * @param mixed $blocks A list of blocks to flatten.
+	 * @param array $blocks A list of blocks to flatten.
 	 */
-	private static function flatten_block_list( $blocks ) {
+	private static function flatten_block_list( $blocks ): array {
 		$result = array();
 		foreach ( $blocks as $block ) {
 			$result = array_merge( $result, self::flatten_inner_blocks( $block ) );
@@ -113,7 +113,7 @@ final class ContentBlocksResolver {
 	 *
 	 * @param mixed $block A block.
 	 */
-	private static function flatten_inner_blocks( $block ) {
+	private static function flatten_inner_blocks( $block ): array {
 		$result            = array();
 		$block['clientId'] = isset( $block['clientId'] ) ? $block['clientId'] : uniqid();
 		array_push( $result, $block );

--- a/includes/Field/BlockSupports/Anchor.php
+++ b/includes/Field/BlockSupports/Anchor.php
@@ -20,7 +20,7 @@ class Anchor {
 	 *
 	 * @param \WP_Block_Type $block_spec .
 	 */
-	public static function register( \WP_Block_Type $block_spec ) {
+	public static function register( \WP_Block_Type $block_spec ): void {
 		if ( isset( $block_spec->supports['anchor'] ) && true === $block_spec->supports['anchor'] ) {
 			register_graphql_interface_type(
 				'BlockWithSupportsAnchor',

--- a/includes/Registry/Registry.php
+++ b/includes/Registry/Registry.php
@@ -7,7 +7,6 @@
 
 namespace WPGraphQL\ContentBlocks\Registry;
 
-use Exception;
 use WP_Block_Type;
 use WPGraphQL\ContentBlocks\Blocks\Block;
 use WPGraphQL\ContentBlocks\Type\Scalar\Scalar;
@@ -223,7 +222,7 @@ final class Registry {
 	 *
 	 * @param \WP_Block_Type $block The block type to register.
 	 */
-	protected function register_block_type( WP_Block_Type $block ) {
+	protected function register_block_type( WP_Block_Type $block ): void {
 		$block_name = ! empty( $block->name ) ? $block->name : 'Core/HTML';
 
 		$type_name  = preg_replace( '/\//', '', lcfirst( ucwords( $block_name, '/' ) ) );

--- a/includes/Type/InterfaceType/EditorBlockInterface.php
+++ b/includes/Type/InterfaceType/EditorBlockInterface.php
@@ -49,7 +49,7 @@ final class EditorBlockInterface {
 	/**
 	 * Registers the types to WPGraphQL.
 	 */
-	public static function register_type() {
+	public static function register_type(): void {
 		register_graphql_interface_type(
 			'NodeWithEditorBlocks',
 			array(

--- a/includes/Type/Scalar/Scalar.php
+++ b/includes/Type/Scalar/Scalar.php
@@ -14,7 +14,7 @@ final class Scalar {
 	/**
 	 * Scalar init procedure.
 	 */
-	public function init() {
+	public function init(): void {
 		register_graphql_scalar(
 			'BlockAttributesObject',
 			array(
@@ -28,7 +28,7 @@ final class Scalar {
 	/**
 	 * Return type name of BlockAttributesObject.
 	 */
-	public static function get_block_attributes_object_type_name() {
+	public static function get_block_attributes_object_type_name(): string {
 		return 'BlockAttributesObject';
 	}
 }

--- a/includes/WPGraphQLContentBlocks.php
+++ b/includes/WPGraphQLContentBlocks.php
@@ -159,7 +159,7 @@ final class WPGraphQLContentBlocks {
 	 *
 	 * @since 0.0.1
 	 */
-	public function actions() {
+	public function actions(): void {
 		add_action( 'graphql_register_types', array( $this, 'init_block_editor_registry' ) );
 	}
 
@@ -168,14 +168,14 @@ final class WPGraphQLContentBlocks {
 	 *
 	 * @since 0.0.1
 	 */
-	public function filters() {     }
+	public function filters(): void {     }
 
 	/**
 	 * Initialize the Block Editor Registry
 	 *
 	 * @param \WPGraphQL\Registry\TypeRegistry $type_registry Type Registry.
 	 */
-	public function init_block_editor_registry( \WPGraphQL\Registry\TypeRegistry $type_registry ) {
+	public function init_block_editor_registry( \WPGraphQL\Registry\TypeRegistry $type_registry ): void {
 		$block_editor_registry = new \WPGraphQL\ContentBlocks\Registry\Registry( $type_registry, \WP_Block_Type_Registry::get_instance() );
 		$block_editor_registry->init();
 	}
@@ -188,7 +188,7 @@ final class WPGraphQLContentBlocks {
 	 * @param string      $name  Constant name.
 	 * @param string|bool $value Constant value.
 	 */
-	private function define( $name, $value ) {
+	private function define( $name, $value ): void {
 		if ( ! defined( $name ) ) {
 			// phpcs:ignore
 			define($name, $value);


### PR DESCRIPTION
This PR adds return types to several method signatures.

No actual change in method behavior or expectation has been made.

Caught by PHPStan Level 6