### PR TITLE
fix: [PHPStan] WPGraphQLHelpers::format_type_name() handling

### DIFF
--- a/.changeset/poor-books-heal.md
+++ b/.changeset/poor-books-heal.md
@@ -1,0 +1,5 @@
+---
+"@wpengine/wp-graphql-content-blocks": patch
+---
+
+fix: Improve `WPGraphQLHelpers::format_type_name()` handling of `null` and empty strings, and use it in more places in the codebase.

--- a/includes/Registry/Registry.php
+++ b/includes/Registry/Registry.php
@@ -228,7 +228,7 @@ final class Registry {
 
 		$type_name  = WPGraphQLHelpers::format_type_name( $block_name );
 		$class_name = Utils::format_type_name( $type_name );
-		$class_name = '\\WPGraphQL\\ContentBlocks\\Blocks\\' . $type_name;
+		$class_name = '\\WPGraphQL\\ContentBlocks\\Blocks\\' . $class_name;
 
 		/**
 		 * This allows 3rd party extensions to hook and and provide

--- a/includes/Registry/Registry.php
+++ b/includes/Registry/Registry.php
@@ -226,10 +226,9 @@ final class Registry {
 	protected function register_block_type( WP_Block_Type $block ) {
 		$block_name = ! empty( $block->name ) ? $block->name : 'Core/HTML';
 
-		$type_name  = preg_replace( '/\//', '', lcfirst( ucwords( $block_name, '/' ) ) );
-		$type_name  = Utils::format_type_name( $type_name );
+		$type_name  = WPGraphQLHelpers::format_type_name( $block_name );
 		$class_name = Utils::format_type_name( $type_name );
-		$class_name = '\\WPGraphQL\\ContentBlocks\\Blocks\\' . $class_name;
+		$class_name = '\\WPGraphQL\\ContentBlocks\\Blocks\\' . $type_name;
 
 		/**
 		 * This allows 3rd party extensions to hook and and provide

--- a/includes/Type/InterfaceType/EditorBlockInterface.php
+++ b/includes/Type/InterfaceType/EditorBlockInterface.php
@@ -8,8 +8,8 @@
 namespace WPGraphQL\ContentBlocks\Type\InterfaceType;
 
 use WP_Block_Type_Registry;
-use WPGraphQL\Utils\Utils;
 use WPGraphQL\ContentBlocks\Data\ContentBlocksResolver;
+use WPGraphQL\ContentBlocks\Utilities\WPGraphQLHelpers;
 
 /**
  * Class EditorBlockInterface
@@ -154,8 +154,8 @@ final class EditorBlockInterface {
 					}
 
 					$type_name = lcfirst( ucwords( $block['blockName'], '/' ) );
-					$type_name = preg_replace( '/\//', '', lcfirst( ucwords( $type_name, '/' ) ) );
-					return Utils::format_type_name( $type_name );
+
+					return WPGraphQLHelpers::format_type_name( $type_name );
 				},
 			)
 		);

--- a/includes/Type/InterfaceType/PostTypeBlockInterface.php
+++ b/includes/Type/InterfaceType/PostTypeBlockInterface.php
@@ -8,7 +8,7 @@
 namespace WPGraphQL\ContentBlocks\Type\InterfaceType;
 
 use WPGraphQL\ContentBlocks\Data\ContentBlocksResolver;
-use WPGraphQL\Utils\Utils;
+use WPGraphQL\ContentBlocks\Utilities\WPGraphQLHelpers;
 
 /**
  * Class PostTypeBlockInterface
@@ -20,7 +20,7 @@ final class PostTypeBlockInterface {
 	 * @param string   $post_type The post type.
 	 * @param string[] $block_names The list of allowed block names.
 	 */
-	public static function register_type( string $post_type, $block_names ) {
+	public static function register_type( string $post_type, $block_names ): void {
 		register_graphql_interface_type(
 			ucfirst( $post_type ) . 'EditorBlock',
 			array(
@@ -36,8 +36,8 @@ final class PostTypeBlockInterface {
 					}
 
 					$type_name = lcfirst( ucwords( $block['blockName'], '/' ) );
-					$type_name = preg_replace( '/\//', '', lcfirst( ucwords( $type_name, '/' ) ) );
-					return Utils::format_type_name( $type_name );
+
+					return WPGraphQLHelpers::format_type_name( $type_name );
 				},
 			)
 		);

--- a/includes/utilities/WPGraphqlHelpers.php
+++ b/includes/utilities/WPGraphqlHelpers.php
@@ -17,14 +17,19 @@ final class WPGraphQLHelpers {
 	 * Formats the name of the block for the GraphQL registry
 	 *
 	 * @param string $name The name of the block.
-	 * @return string
 	 */
-	public static function format_type_name( $name ) {
+	public static function format_type_name( $name ): string {
+		// No need to string-replace if there's no string.
+		if ( empty( $name ) ) {
+			return '';
+		}
+
 		// Format the type name for showing in the GraphQL Schema
 		// @todo: WPGraphQL utility function should handle removing the '/' by default.
 		$type_name = lcfirst( ucwords( $name, '/' ) );
 		$type_name = preg_replace( '/\//', '', lcfirst( ucwords( $type_name, '/' ) ) );
-		$type_name = Utils::format_type_name( $type_name );
-		return Utils::format_type_name( $type_name );
+		$type_name = null !== $type_name ? Utils::format_type_name( $type_name ) : '';
+
+		return ! empty( $type_name ) ? Utils::format_type_name( $type_name ) : $type_name;
 	}
 }

--- a/includes/utilities/WPHelpers.php
+++ b/includes/utilities/WPHelpers.php
@@ -22,8 +22,12 @@ final class WPHelpers {
 	 */
 	public static function get_supported_post_types(): array {
 		$supported_post_types = array();
-		// Get Post Types that are set to Show in GraphQL and Show in REST
-		// If it doesn't show in REST, it's not block-editor enabled
+		/**
+		 * Get Post Types that are set to Show in GraphQL and Show in REST.
+		 * If it doesn't show in REST, it's not block-editor.
+		 *
+		 * @var \WP_Post_Type[] $block_editor_post_types
+		 */
 		$block_editor_post_types = \WPGraphQL::get_allowed_post_types( 'objects' );
 
 		if ( empty( $block_editor_post_types ) || ! is_array( $block_editor_post_types ) ) {


### PR DESCRIPTION
This PR refactors `WPGraphQLHelpers::format_type_name()` to better handle empty string / null values, as well as DRYs up the codebase to use it in more places.

This PR **does not** address the _seemingly_ duplicate renaming that entered the codebase in #52 . 

Caught by PHPStan level 6