### PR TITLE
fix: better type checking in Block.php methods

### DIFF
--- a/.changeset/orange-actors-watch.md
+++ b/.changeset/orange-actors-watch.md
@@ -1,0 +1,5 @@
+---
+"@wpengine/wp-graphql-content-blocks": patch
+---
+
+fix: Implement better type checking in `Blocks\Block` class to prevent possible fatal errors on edge cases.

--- a/includes/Blocks/Block.php
+++ b/includes/Blocks/Block.php
@@ -7,9 +7,7 @@
 
 namespace WPGraphQL\ContentBlocks\Blocks;
 
-use GraphQL\Type\Definition\ResolveInfo;
 use WP_Block_Type;
-use WPGraphQL\AppContext;
 use WPGraphQL\ContentBlocks\Registry\Registry;
 use WPGraphQL\ContentBlocks\Utilities\DOMHelpers;
 use WPGraphQL\ContentBlocks\Utilities\WPGraphQLHelpers;
@@ -97,7 +95,8 @@ class Block {
 	 */
 	private function register_block_attributes_as_fields() {
 		if ( isset( $this->additional_block_attributes ) ) {
-			$block_attribute_fields = $this->get_block_attribute_fields( array_merge( $this->block_attributes, $this->additional_block_attributes ) );
+			$block_attributes       = ! empty( $this->block_attributes ) ? array_merge( $this->block_attributes, $this->additional_block_attributes ) : $this->additional_block_attributes;
+			$block_attribute_fields = $this->get_block_attribute_fields( $block_attributes );
 		} else {
 			$block_attribute_fields = $this->get_block_attribute_fields( $this->block_attributes );
 		}
@@ -280,7 +279,7 @@ class Block {
 				case 'html':
 					$value = DOMHelpers::parseHTML( $rendered_block, $attribute_config['selector'], $default );
 
-					if ( isset( $attribute_config['multiline'] ) ) {
+					if ( isset( $attribute_config['multiline'] ) && ! empty( $value ) ) {
 						$value = DOMHelpers::getElementsFromHTML( $value, $attribute_config['multiline'] );
 					}
 


### PR DESCRIPTION
This PR fixes two issues in the `Block` class, where a lack of type safety could cause a fatal PHP error.

Caught by PHPStan level 8