### PR TITLE
Add support for reusable blocks

### DIFF
--- a/.changeset/gorgeous-horses-arrive.md
+++ b/.changeset/gorgeous-horses-arrive.md
@@ -1,0 +1,5 @@
+---
+"@wpengine/wp-graphql-content-blocks": minor
+---
+
+Add support for Reusable Blocks

--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@ artifacts
 # docker
 .docker/plugins/
 !.docker/plugins/test-cpt
+docker-compose.override.yml
 
 # Built Zip
 @wpengine

--- a/includes/Data/ContentBlocksResolver.php
+++ b/includes/Data/ContentBlocksResolver.php
@@ -54,20 +54,20 @@ final class ContentBlocksResolver {
 			return array();
 		}
 
-        // Resolve reusable blocks - replaces "core/block" with the corresponding block(s) from the reusable ref ID
-        $new_parsed_blocks = [];
-        foreach ($parsed_blocks as $block) {
-            if ($block['blockName'] === 'core/block' && $block['attrs']['ref']) {
-                $reusable_blocks = parse_blocks( get_post( $block['attrs']['ref'] )->post_content );
-                if (!empty($reusable_blocks)) {
-                    array_push($new_parsed_blocks, ...$reusable_blocks);
-                }
-            } else {
-                $new_parsed_blocks[] = $block;
-            }
-        }
+		// Resolve reusable blocks - replaces "core/block" with the corresponding block(s) from the reusable ref ID
+		$new_parsed_blocks = array();
+		foreach ( $parsed_blocks as $block ) {
+			if ( 'core/block' === $block['blockName'] && $block['attrs']['ref'] ) {
+				$reusable_blocks = parse_blocks( get_post( $block['attrs']['ref'] )->post_content );
+				if ( ! empty( $reusable_blocks ) ) {
+					array_push( $new_parsed_blocks, ...$reusable_blocks );
+				}
+			} else {
+				$new_parsed_blocks[] = $block;
+			}
+		}
 
-        $parsed_blocks = $new_parsed_blocks;
+		$parsed_blocks = $new_parsed_blocks;
 
 		// 1st Level filtering of blocks that are empty
 		$parsed_blocks = array_filter(

--- a/includes/Data/ContentBlocksResolver.php
+++ b/includes/Data/ContentBlocksResolver.php
@@ -53,6 +53,22 @@ final class ContentBlocksResolver {
 		if ( empty( $parsed_blocks ) ) {
 			return array();
 		}
+
+        // Resolve reusable blocks - replaces "core/block" with the corresponding block(s) from the reusable ref ID
+        $new_parsed_blocks = [];
+        foreach ($parsed_blocks as $block) {
+            if ($block['blockName'] === 'core/block' && $block['attrs']['ref']) {
+                $reusable_blocks = parse_blocks( get_post( $block['attrs']['ref'] )->post_content );
+                if (!empty($reusable_blocks)) {
+                    array_push($new_parsed_blocks, ...$reusable_blocks);
+                }
+            } else {
+                $new_parsed_blocks[] = $block;
+            }
+        }
+
+        $parsed_blocks = $new_parsed_blocks;
+
 		// 1st Level filtering of blocks that are empty
 		$parsed_blocks = array_filter(
 			$parsed_blocks,

--- a/tests/unit/ContentBlocksResolverTest.php
+++ b/tests/unit/ContentBlocksResolverTest.php
@@ -62,15 +62,15 @@ final class ContentBlocksResolverTest extends PluginTestCase {
 		$post_model = new Post( get_post( $this->post_id ) );
 		$actual     = $this->instance->resolve_content_blocks( $post_model, array( 'flat' => true ) );
 		// There should return only the non-empty blocks
-		$this->assertEquals( count( $actual ), 6 );
-		$this->assertEquals( $actual[0]['blockName'], 'core/columns' );
+		$this->assertEquals( 6, count( $actual ) );
+		$this->assertEquals( 'core/columns', $actual[0]['blockName'] );
 	}
 
 	public function test_resolve_content_blocks_resolves_classic_blocks() {
 		$post_model = new Post( get_post( $this->post_id ) );
 		$actual     = $this->instance->resolve_content_blocks( $post_model, array( 'flat' => true ) );
 
-		$this->assertEquals( $actual[5]['blockName'], 'core/freeform' );
+		$this->assertEquals( 'core/freeform', $actual[5]['blockName'] );
 	}
 
 	public function test_resolve_content_blocks_filters_blocks_not_from_allow_list() {
@@ -88,7 +88,7 @@ final class ContentBlocksResolverTest extends PluginTestCase {
 			)
 		);
 		// There should return only blocks from the allow list
-		$this->assertEquals( count( $parsed_blocks ), 4 );
-		$this->assertEquals( $actual_block_names, $allowed );
+		$this->assertEquals( 4, count( $parsed_blocks ) );
+		$this->assertEquals( $allowed, $actual_block_names  );
 	}
 }

--- a/tests/unit/ContentBlocksResolverTest.php
+++ b/tests/unit/ContentBlocksResolverTest.php
@@ -9,10 +9,11 @@ final class ContentBlocksResolverTest extends PluginTestCase {
 	public $instance;
 	public $post_id;
 	public $reusable_post_id;
+	public $reusable_block_id;
 
 	public function setUp(): void {
 		parent::setUp();
-		$reusable_id = wp_insert_post(
+		$this->reusable_block_id = wp_insert_post(
 			array(
 				'post_title' => 'Reusable Block',
 				'post_type' => 'wp_block',
@@ -31,12 +32,13 @@ final class ContentBlocksResolverTest extends PluginTestCase {
 			)
 		);
 
-        $this->reusable_post_id = wp_insert_post(
-            array(
-                'post_title' => 'Post Title',
-                'post_content' => '<!-- wp:block {"ref":' . $reusable_id . '} /-->'
-            )
-        );
+		$this->reusable_post_id  = wp_insert_post(
+			array(
+				'post_title'   => 'Post Title',
+				'post_content' => '<!-- wp:block {"ref":' . $this->reusable_block_id . '} /-->',
+				'post_status'  => 'publish',
+			)
+		);
 
 		$this->post_id  = wp_insert_post(
 			array(
@@ -50,7 +52,7 @@ final class ContentBlocksResolverTest extends PluginTestCase {
                 <!--  -->
                 <!-- wp -->
                 <!-- /wp -->
-
+                
                 <!-- wp: -->
                 <!-- /wp: -->
 
@@ -76,6 +78,7 @@ final class ContentBlocksResolverTest extends PluginTestCase {
 				'post_status'  => 'publish',
 			)
 		);
+
 		$this->instance = new ContentBlocksResolver();
 	}
 
@@ -83,11 +86,14 @@ final class ContentBlocksResolverTest extends PluginTestCase {
 		// your tear down methods here
 		parent::tearDown();
 		wp_delete_post( $this->post_id, true );
+		wp_delete_post( $this->reusable_post_id, true );
+		wp_delete_post( $this->reusable_block_id, true );
 	}
 
     public function test_resolve_content_blocks_resolves_reusable_blocks() {
         $post_model = new Post( get_post( $this->reusable_post_id ) );
         $actual     = $this->instance->resolve_content_blocks( $post_model, array( 'flat' => true ) );
+
         // There should return only the non-empty blocks
 		$this->assertEquals( 3, count( $actual ) );
 		$this->assertEquals( 'core/columns', $actual[0]['blockName'] );

--- a/tests/unit/ContentBlocksResolverTest.php
+++ b/tests/unit/ContentBlocksResolverTest.php
@@ -20,13 +20,15 @@ final class ContentBlocksResolverTest extends PluginTestCase {
 				'post_content' => preg_replace(
 					'/\s+/',
 					' ',
-					trim('
+					trim(
+						'
 				<!-- wp:columns -->
 				<div class="wp-block-columns"><!-- wp:column -->
 				<div class="wp-block-column"><!-- wp:paragraph -->
 				<p>Example paragraph in Column 1</p>
 				<!-- /wp:paragraph --></div>
-				<!-- /wp:column -->'
+				<!-- /wp:column -->
+				'
 					)
 				)
 			)


### PR DESCRIPTION
This PR adds support for reusable blocks, rather than simply returning a core/block response. It detects if a reusable block has been found and if so, opens the post and parses the blocks from that, replacing the core/block with the newly parsed blocks.

This is probably a breaking change, given it's no longer sending a core/block response but it would equally be breaking if the core/block was mutated to embed the blocks within innerBlocks or similar. This in my opinion is the most compatible approach, it allows the reusable blocks to simply appear as if they were non-reusable from the GQL response perspective - allowing end users to change from reusable <> non-reusable with zero difference in the GQL response output - which feels sensible from my perspective.
