### PR TITLE
Fix regression - Allow blocks with names to pass filtering, even if empty when rendered

### DIFF
--- a/includes/Data/ContentBlocksResolver.php
+++ b/includes/Data/ContentBlocksResolver.php
@@ -57,6 +57,10 @@ final class ContentBlocksResolver {
 		$parsed_blocks = array_filter(
 			$parsed_blocks,
 			function ( $parsed_block ) {
+				if (! empty( $parsed_block['blockName'] )) {
+					return true;
+				}
+
 				// Strip empty comments and spaces
 				$stripped = preg_replace( '/<!--(.*)-->/Uis', '', render_block( $parsed_block ) );
 				return ! empty( trim( $stripped ?? '' ) );


### PR DESCRIPTION
Adds a fix for a regression caused by #59 

Blocks may intentionally be empty rendered, and the properties passed to the frontend for rendering on the frontend the previous change in this file caused a regression which blocked those use cases, while adding support for Classic Editor blocks (which didn't have a name and were therefore filtered).

This PR allows both:
- If blocks have a name, they pass the filter regardless.
- Then the block is rendered and checked for empty()

As a side-effect, this should be more performant as it's avoiding a render.