### PR TITLE
Only register the anchor once, then apply to the block

### DIFF
--- a/.changeset/great-ravens-joke.md
+++ b/.changeset/great-ravens-joke.md
@@ -1,0 +1,5 @@
+---
+"@wpengine/wp-graphql-content-blocks": minor
+---
+
+Fix regression with addition of anchor support - only register interface once

--- a/includes/Blocks/Block.php
+++ b/includes/Blocks/Block.php
@@ -135,7 +135,7 @@ class Block {
 	 * Registers fields for the block supports.
 	 */
 	private function register_block_support_fields(): void {
-		Anchor::register( $this->block );
+		Anchor::register_to_block( $this->block );
 	}
 
 	/**

--- a/includes/Blocks/Block.php
+++ b/includes/Blocks/Block.php
@@ -83,9 +83,9 @@ class Block {
 	 */
 	private function register_block_type() {
 		$this->register_block_attributes_as_fields();
-		$this->register_block_support_fields();
 		$this->register_fields();
 		$this->register_type();
+		$this->register_block_support_fields();
 	}
 
 	/**

--- a/includes/Field/BlockSupports/Anchor.php
+++ b/includes/Field/BlockSupports/Anchor.php
@@ -16,9 +16,7 @@ use WPGraphQL\ContentBlocks\Utilities\WPGraphQLHelpers;
  */
 class Anchor {
 	/**
-	 * Registers an Anchor field on a block if it supports it.
-	 *
-	 * @param \WP_Block_Type $block_spec .
+	 * Registers the Anchor interface
 	 */
 	public static function register(): void {
 		register_graphql_interface_type(
@@ -44,10 +42,16 @@ class Anchor {
 		);
 	}
 
-	public static function register_to_block( \WP_Block_Type $block_spec ) : void {
+	/**
+	 * Registers an Anchor field on a block if it supports it.
+	 *
+	 * @param \WP_Block_Type $block_spec The block type to register the anchor field against.
+	 * @return void
+	 */
+	public static function register_to_block( \WP_Block_Type $block_spec ): void {
 		if ( isset( $block_spec->supports['anchor'] ) && true === $block_spec->supports['anchor'] ) {
-			register_graphql_interfaces_to_types('BlockWithSupportsAnchor', array(WPGraphQLHelpers::format_type_name($block_spec->name) . 'Attributes'));
-			register_graphql_interfaces_to_types('BlockWithSupportsAnchor', array(WPGraphQLHelpers::format_type_name($block_spec->name)));
+			register_graphql_interfaces_to_types( 'BlockWithSupportsAnchor', array( WPGraphQLHelpers::format_type_name( $block_spec->name ) . 'Attributes' ) );
+			register_graphql_interfaces_to_types( 'BlockWithSupportsAnchor', array( WPGraphQLHelpers::format_type_name( $block_spec->name ) ) );
 		}
 	}
 }

--- a/includes/Field/BlockSupports/Anchor.php
+++ b/includes/Field/BlockSupports/Anchor.php
@@ -20,31 +20,34 @@ class Anchor {
 	 *
 	 * @param \WP_Block_Type $block_spec .
 	 */
-	public static function register( \WP_Block_Type $block_spec ): void {
-		if ( isset( $block_spec->supports['anchor'] ) && true === $block_spec->supports['anchor'] ) {
-			register_graphql_interface_type(
-				'BlockWithSupportsAnchor',
-				array(
-					'description' => __( 'Block that supports Anchor field', 'wp-graphql-content-blocks' ),
-					'fields'      => array(
-						'anchor' => array(
-							'type'        => 'string',
-							'description' => __( 'The anchor field for the block.', 'wp-graphql-content-blocks' ),
-							'resolve'     => function ( $block ) {
-								$rendered_block   = wp_unslash( render_block( $block ) );
-								$value            = null;
-								if ( empty( $rendered_block ) ) {
-									return $value;
-								}
-								$value = DOMHelpers::parseFirstNodeAttribute( $rendered_block, 'id' );
+	public static function register(): void {
+		register_graphql_interface_type(
+			'BlockWithSupportsAnchor',
+			array(
+				'description' => __( 'Block that supports Anchor field', 'wp-graphql-content-blocks' ),
+				'fields'      => array(
+					'anchor' => array(
+						'type'        => 'string',
+						'description' => __( 'The anchor field for the block.', 'wp-graphql-content-blocks' ),
+						'resolve'     => function ( $block ) {
+							$rendered_block   = wp_unslash( render_block( $block ) );
+							$value            = null;
+							if ( empty( $rendered_block ) ) {
 								return $value;
-							},
-						),
+							}
+							$value = DOMHelpers::parseFirstNodeAttribute( $rendered_block, 'id' );
+							return $value;
+						},
 					),
-				)
-			);
-			register_graphql_interfaces_to_types( 'BlockWithSupportsAnchor', array( WPGraphQLHelpers::format_type_name( $block_spec->name ) . 'Attributes' ) );
-			register_graphql_interfaces_to_types( 'BlockWithSupportsAnchor', array( WPGraphQLHelpers::format_type_name( $block_spec->name ) ) );
-		}//end if
+				),
+			)
+		);
+	}
+
+	public static function register_to_block( \WP_Block_Type $block_spec ) : void {
+		if ( isset( $block_spec->supports['anchor'] ) && true === $block_spec->supports['anchor'] ) {
+			register_graphql_interfaces_to_types('BlockWithSupportsAnchor', array(WPGraphQLHelpers::format_type_name($block_spec->name) . 'Attributes'));
+			register_graphql_interfaces_to_types('BlockWithSupportsAnchor', array(WPGraphQLHelpers::format_type_name($block_spec->name)));
+		}
 	}
 }

--- a/includes/Registry/Registry.php
+++ b/includes/Registry/Registry.php
@@ -9,6 +9,7 @@ namespace WPGraphQL\ContentBlocks\Registry;
 
 use WP_Block_Type;
 use WPGraphQL\ContentBlocks\Blocks\Block;
+use WPGraphQL\ContentBlocks\Field\BlockSupports\Anchor;
 use WPGraphQL\ContentBlocks\Type\Scalar\Scalar;
 use WPGraphQL\ContentBlocks\Type\InterfaceType\EditorBlockInterface;
 use WPGraphQL\ContentBlocks\Type\InterfaceType\PostTypeBlockInterface;
@@ -70,6 +71,7 @@ final class Registry {
 		$this->register_interface_types();
 		$this->register_scalar_types();
 		$this->register_block_types();
+		$this->register_support_block_types();
 	}
 
 	/**
@@ -239,5 +241,10 @@ final class Registry {
 		} else {
 			new Block( $block, $this );
 		}
+	}
+
+	protected function register_support_block_types()
+	{
+		Anchor::register();
 	}
 }

--- a/includes/Registry/Registry.php
+++ b/includes/Registry/Registry.php
@@ -243,8 +243,12 @@ final class Registry {
 		}
 	}
 
-	protected function register_support_block_types()
-	{
+	/**
+	 * Register supporting block types
+	 *
+	 * @return void
+	 */
+	protected function register_support_block_types() {
 		Anchor::register();
 	}
 }


### PR DESCRIPTION
Fixes #98.

The interface was being registered for any block that supported anchors, if more than one block supported them then GraphQL was complaining about duplicate entries. This moves the registering of the interface to the registry and then the application of that interface within the block registering flow only registers that interface to the type/block.