### PR TITLE
Add the `cssClassName` attribute to `CoreQuote`

### DIFF
--- a/.changeset/pretty-owls-decide.md
+++ b/.changeset/pretty-owls-decide.md
@@ -1,0 +1,5 @@
+---
+"@wpengine/wp-graphql-content-blocks": patch
+---
+
+Added `cssClassName` attribute on `CoreQuote` Block

--- a/includes/Blocks/CoreQuote.php
+++ b/includes/Blocks/CoreQuote.php
@@ -1,0 +1,27 @@
+<?php
+/**
+ * Core Quote Block
+ *
+ * @package WPGraphQL\ContentBlocks\Blocks
+ */
+
+namespace WPGraphQL\ContentBlocks\Blocks;
+
+/**
+ * Class CoreQuote
+ */
+class CoreQuote extends Block {
+	/**
+	 * {@inheritDoc}
+	 *
+	 * @var array|null
+	 */
+	protected ?array $additional_block_attributes = array(
+		'cssClassName' => array(
+			'type'      => 'string',
+			'selector'  => 'pre',
+			'source'    => 'attribute',
+			'attribute' => 'class',
+		),
+	);
+}


### PR DESCRIPTION
This PR adds the `cssClassName` attribute to `CoreQuote` for our blocks library.