### PR TITLE
Feat: Add CoreSeparator cssClassNames

### DIFF
--- a/includes/Blocks/CoreSeparator.php
+++ b/includes/Blocks/CoreSeparator.php
@@ -1,0 +1,27 @@
+<?php
+/**
+ * Core Separator Block
+ *
+ * @package WPGraphQL\ContentBlocks\Blocks
+ */
+
+namespace WPGraphQL\ContentBlocks\Blocks;
+
+/**
+ * Class Separator
+ */
+class CoreSeparator extends Block {
+	/**
+	 * {@inheritDoc}
+	 *
+	 * @var array|null
+	 */
+	protected ?array $additional_block_attributes = array(
+		'cssClassName' => array(
+			'type'      => 'string',
+			'selector'  => 'hr',
+			'source'    => 'attribute',
+			'attribute' => 'class',
+		),
+	);
+}


### PR DESCRIPTION
# Description
Adds cssClassName attribute in CoreSeparator

# Test
Check that the `cssClassName` attribute is available in the CoreSeparator block.