### PR TITLE
[Merl-786] `post_type_supports` -> `use_block_editor_for_post_type`

### DIFF
--- a/.changeset/odd-files-attend.md
+++ b/.changeset/odd-files-attend.md
@@ -1,5 +1,6 @@
 ---
-"@wpengine/wp-graphql-content-blocks": patch
+"@wpengine/wp-graphql-content-blocks": major
 ---
 
 Fix: use `use_block_editor_for_post_type` instead of `post_type_supports` when filtering the post types.
+WARNING: Potential BREAKING schema changes on previously exposed blocks that do not support the block editor. Those blocks will no longer inherit the `editorBlocks` field.

--- a/.changeset/odd-files-attend.md
+++ b/.changeset/odd-files-attend.md
@@ -3,4 +3,4 @@
 ---
 
 Fix: use `use_block_editor_for_post_type` instead of `post_type_supports` when filtering the post types.
-WARNING: Potential BREAKING schema changes on previously exposed blocks that do not support the block editor. Those blocks will no longer inherit the `editorBlocks` field.
+**BREAKING**: Potential schema changes on previously exposed blocks that do not support the block editor. Those blocks will no longer inherit the `editorBlocks` field.

--- a/.changeset/odd-files-attend.md
+++ b/.changeset/odd-files-attend.md
@@ -1,0 +1,5 @@
+---
+"@wpengine/wp-graphql-content-blocks": patch
+---
+
+Fix: use `use_block_editor_for_post_type` instead of `post_type_supports` when filtering the post types.

--- a/includes/Utilities/WPHelpers.php
+++ b/includes/Utilities/WPHelpers.php
@@ -33,11 +33,10 @@ final class WPHelpers {
 		if ( empty( $block_editor_post_types ) || ! is_array( $block_editor_post_types ) ) {
 			return $supported_post_types;
 		}
-
 		// Iterate over the post types
 		foreach ( $block_editor_post_types as $block_editor_post_type ) {
 			// If the post type doesn't support the editor, it's not block-editor enabled
-			if ( ! post_type_supports( $block_editor_post_type->name, 'editor' ) ) {
+			if ( ! use_block_editor_for_post_type( $block_editor_post_type->name ) ) {
 				continue;
 			}
 

--- a/tests/unit/RegistryTestCase.php
+++ b/tests/unit/RegistryTestCase.php
@@ -65,6 +65,42 @@ final class RegistryTestCase extends PluginTestCase {
 	}
 
 	/**
+	 * This test ensures that when disabling the block editor for post types then
+	 * no additional interfaces are included in them.
+	 */
+	public function test_no_additional_interfaces_on_block_editor_disabled_block_types() {
+		add_filter('use_block_editor_for_post_type', '__return_false');
+		$query = '
+		query GetType($name:String!) {
+			__type(name: $name) {
+				interfaces {
+					name
+				}
+			}
+		}
+		';
+
+		$this->instance->init();
+
+		// Verify the response contains what we put in cache
+		$response           = graphql(
+			array(
+				'query'     => $query,
+				'variables' => array(
+					'name' => 'Post',
+				),
+			)
+		);
+		$not_included = array(
+			'name'        => 'NodeWithEditorBlocks',
+		);
+		$this->assertArrayHasKey( 'data', $response, json_encode( $response ) );
+		$this->assertNotEmpty( $response['data']['__type']['interfaces'] );
+		$this->assertNotContains( $not_included, $response['data']['__type']['interfaces'] );
+		remove_filter('use_block_editor_for_post_type', '__return_false');
+	}
+
+	/**
 	 * This test ensures that the `register_interface_types()` method
 	 * works as expected when the get_allowed_block_types is used
 	 */


### PR DESCRIPTION
# Description

Replaces the `post_type_supports` with `use_block_editor_for_post_type` when resolving the `get_supported_post_types`. This has the added benefit of running the [use_block_editor_for_post_type](https://developer.wordpress.org/reference/hooks/use_block_editor_for_post_type/) hook that was missed, potentially including blocks that dont work with the block editor. 

## Tasks
- [x] Has automated tests confirming schema accuracy on post types that support blocks and post types that do not support blocks.
- [x] Has been tested with [WPGraphQL for WooCommerce](https://github.com/wp-graphql/wp-graphql-woocommerce/releases)
- [x] Has been tested with WPGraphQL for ACF ([existing](https://github.com/wp-graphql/wp-graphql-acf) and [new](https://github.com/wp-graphql/wpgraphql-acf))
- [x] Has a changeset

Closes #27 
