### PR TITLE
Feat: Add CoreHeading css classNames

### DIFF
--- a/.changeset/curly-spiders-greet.md
+++ b/.changeset/curly-spiders-greet.md
@@ -1,0 +1,5 @@
+---
+"@wpengine/wp-graphql-content-blocks": patch
+---
+
+Adds cssClassName attribute in CoreHeading.

--- a/includes/Blocks/CoreHeading.php
+++ b/includes/Blocks/CoreHeading.php
@@ -1,0 +1,27 @@
+<?php
+/**
+ * Core Heading Block
+ *
+ * @package WPGraphQL\ContentBlocks\Blocks
+ */
+
+namespace WPGraphQL\ContentBlocks\Blocks;
+
+/**
+ * Class CoreHeading
+ */
+class CoreHeading extends Block {
+	/**
+	 * {@inheritDoc}
+	 *
+	 * @var array|null
+	 */
+	protected ?array $additional_block_attributes = array(
+		'cssClassName' => array(
+			'type'      => 'string',
+			'selector'  => 'h1, h2, h3, h4, h5, h6',
+			'source'    => 'attribute',
+			'attribute' => 'class',
+		),
+	);
+}


### PR DESCRIPTION
# Description
Adds a new field for providing the css class for a CoreHeading block.

# Testing
1 Create a CoreHeading block.
2 Query the `cssClassName` attribute. It should extract the class Names of the heading element and it should match the css of the rendered HTML content.

<img width="1258" alt="Screenshot 2023-06-23 at 12 44 52" src="https://github.com/wpengine/wp-graphql-content-blocks/assets/328805/48d94298-c4b8-45a9-9200-811b88878d0f">
