### PR TITLE
Add `cssClassName` to CoreList block

### DIFF
--- a/.changeset/new-planes-itch.md
+++ b/.changeset/new-planes-itch.md
@@ -1,0 +1,5 @@
+---
+"@wpengine/wp-graphql-content-blocks": minor
+---
+
+Adds the `cssClassName` attribute to the `CoreList` block. This allows you to query for the proper class names that WordPress assigns to the Core List block.

--- a/includes/Blocks/CoreList.php
+++ b/includes/Blocks/CoreList.php
@@ -1,0 +1,27 @@
+<?php
+/**
+ * Core List Block
+ *
+ * @package WPGraphQL\ContentBlocks\Blocks
+ */
+
+namespace WPGraphQL\ContentBlocks\Blocks;
+
+/**
+ * Class CoreList
+ */
+class CoreList extends Block {
+	/**
+	 * {@inheritDoc}
+	 *
+	 * @var array|null
+	 */
+	protected ?array $additional_block_attributes = array(
+		'cssClassName' => array(
+			'type'      => 'string',
+			'selector'  => 'ul,ol',
+			'source'    => 'attribute',
+			'attribute' => 'class',
+		),
+	);
+}


### PR DESCRIPTION
Adds the `cssClassName` attribute to the `CoreList` block similar to https://github.com/wpengine/wp-graphql-content-blocks/pull/122

## Testing

1. Create a `CoreList` block on a page or post
2. Query for that page/post in WPGraphQL GraphiQL
3. Query the `cssClassName` attribute on the `CoreList` block
4. Notice the class names come back as expected

<img width="2560" alt="Screenshot 2023-06-26 at 11 39 23 AM" src="https://github.com/wpengine/wp-graphql-content-blocks/assets/5946219/8e8a512d-6f10-4a7b-b277-4a4b36b76a6b">


