### PR TITLE
POC: Use WPGraphQL Coding Standards

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,5 +23,8 @@ artifacts
 !.docker/plugins/test-cpt
 docker-compose.override.yml
 
+# phpcs cache
+/tests/_output/cache.json
+
 # Built Zip
 @wpengine

--- a/.phpcs.xml.dist
+++ b/.phpcs.xml.dist
@@ -1,45 +1,60 @@
 <?xml version="1.0"?>
-<ruleset name="WordPress Coding Standards based custom ruleset for your plugin">
-	<description>Generally-applicable sniffs for WordPress plugins.</description>
+<ruleset name="WordPress Coding Standards for WPGraphQL Plugins" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/squizlabs/PHP_CodeSniffer/master/phpcs.xsd">
+	<description>Sniffs for WPGraphQL Content Blocks</description>
 
-	<file>.</file>
-
-	<!-- Exclude composer vendor directory -->
+	<!-- What to scan: include any root-level PHP files, and the /includes folder -->
+	<file>./wp-graphql-content-blocks.php</file>
+	<file>./includes/</file>
 	<exclude-pattern>/vendor/</exclude-pattern>
 	<exclude-pattern>/node_modules/</exclude-pattern>
-	<exclude-pattern>/phpstan/</exclude-pattern>
-	<exclude-pattern>/tests/</exclude-pattern>
+	<exclude-pattern>**/tests/**</exclude-pattern>
 
-	<!-- How to scan -->
+	<!-- How to scan: include CLI args so you don't need to pass them manually -->
 	<!-- Usage instructions: https://github.com/squizlabs/PHP_CodeSniffer/wiki/Usage -->
 	<!-- Annotated ruleset: https://github.com/squizlabs/PHP_CodeSniffer/wiki/Annotated-ruleset.xml -->
-	<arg value="sp" />
-	<arg name="basepath" value="./" />
-	<arg name="colors" />
-	<arg name="extensions" value="php" />
-	<arg name="parallel" value="8" />
 
-	<!-- Rules: Check PHP version compatibility -->
-	<!-- https://github.com/PHPCompatibility/PHPCompatibility#sniffing-your-code-for-compatibility-with-specific-php-versions -->
-	<config name="testVersion" value="7.4-" />
+	<!-- Show sniff and progress -->
+	<arg value="sp"/>
+	<!-- Strip the file paths down to the relevant bit -->
+	<arg name="basepath" value="./"/>
+	<!-- Enable colors in report -->
+	<arg name="colors"/>
+	<!-- Only lint php files by default -->
+	<arg name="extensions" value="php"/>
+	<!-- Whenever possible, cache the scan results and re-use those for unchanged files on the next scan. -->
+	<arg name="cache" value="tests/_output/cache.json" />
+	<!-- Enables parallel processing when available for faster results. -->
+	<arg name="parallel" value="20"/>
+	<!-- Set severity to 1 to see everything that isn't effectively turned off. -->
+	<arg name="severity" value="1" />
 
-	<!-- https://github.com/wpengine/wpengine-coding-standards -->
-	<rule ref="WP-Engine-Strict"/>
+	<!-- Ruleset Config: set these to match your project constraints-->
 
-	<!-- https://github.com/PHPCompatibility/PHPCompatibilityWP -->
-	<rule ref="PHPCompatibilityWP" />
+	<!--
+		Tests for PHP version compatibility.
+		https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards#Recomended-additional-rulesets
+	-->
+	<config name="testVersion" value="7.4-"/>
 
-	<!-- Rules: WordPress Coding Standards -->
-	<!-- https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards -->
-	<!-- https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/wiki/Customizable-sniff-properties -->
-	<config name="minimum_supported_wp_version" value="5.3" />
+	<!--
+		Tests for WordPress version compatibility.
+		https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/wiki/Customizable-sniff-properties
+	-->
+	<config name="minimum_supported_wp_version" value="5.3"/>
 
-	<rule ref="WordPress">
+	<!-- Rules: WPGraphQL Coding Standards -->
+	<!-- https://github.com/AxeWP/WPGraphQL-Coding-Standards/WPGraphQL/ruleset.xml -->
+	<rule ref="WPGraphQL-Minimum">
+		<!-- The is the only thing missing from WPEngine-Strict -->
+		<exclude name="Squiz.Commenting.InlineComment.InvalidEndChar" />
+		<!-- This should be excluded upstream in the ruleset-->
 		<exclude name="WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase" />
 	</rule>
 
+	<!-- Individual rule configuration -->
 	<rule ref="WordPress.NamingConventions.PrefixAllGlobals">
 		<properties>
+			<!-- Value: replace the function, class, and variable prefixes used. Separate multiple prefixes with a comma. -->
 			<property name="prefixes" type="array">
 				<element value="wpgraphql\content_blocks" />
 				<element value="WPGRAPHQL\CONTENT_BLOCKS" />
@@ -49,26 +64,17 @@
 			</property>
 		</properties>
 	</rule>
-
 	<rule ref="WordPress.WP.I18n">
 		<properties>
+			<!-- Value: replace the text domain used. -->
 			<property name="text_domain" type="array" value="wp-graphql-content-blocks" />
 		</properties>
 	</rule>
 
-	<rule ref="WordPress.WhiteSpace.ControlStructureSpacing">
-		<properties>
-			<property name="blank_line_check" value="true" />
-		</properties>
-	</rule>
-
-	<rule ref="WordPress.Files.FileName">
-		<exclude name="WordPress.Files.FileName.NotHyphenatedLowercase" />
-		<exclude name="WordPress.Files.FileName.InvalidClassFileName" />
-	</rule>
-
+	
 	<!-- Exclude rules that break PHP Unit test conventions or result in redundant comments. -->
 	<!-- Test functions and properties are self-describing. -->
+	<!-- @todo These shouldnt be necessary, since tests are excluded -->
 	<rule ref="Generic.Commenting.DocComment.MissingShort">
 		<exclude-pattern>/tests/</exclude-pattern>
 	</rule>
@@ -132,5 +138,4 @@
 		<exclude-pattern>/tests/</exclude-pattern>
 	</rule>
 
-	
 </ruleset>

--- a/.phpcs.xml.dist
+++ b/.phpcs.xml.dist
@@ -44,7 +44,7 @@
 
 	<!-- Rules: WPGraphQL Coding Standards -->
 	<!-- https://github.com/AxeWP/WPGraphQL-Coding-Standards/WPGraphQL/ruleset.xml -->
-	<rule ref="WPGraphQL-Minimum">
+	<rule ref="WPGraphQL-Strict">
 		<!-- The is the only thing missing from WPEngine-Strict -->
 		<exclude name="Squiz.Commenting.InlineComment.InvalidEndChar" />
 		<!-- This should be excluded upstream in the ruleset-->

--- a/.phpcs.xml.dist
+++ b/.phpcs.xml.dist
@@ -44,7 +44,7 @@
 
 	<!-- Rules: WPGraphQL Coding Standards -->
 	<!-- https://github.com/AxeWP/WPGraphQL-Coding-Standards/WPGraphQL/ruleset.xml -->
-	<rule ref="WPGraphQL-Strict">
+	<rule ref="WPGraphQL">
 		<!-- The is the only thing missing from WPEngine-Strict -->
 		<exclude name="Squiz.Commenting.InlineComment.InvalidEndChar" />
 		<!-- This should be excluded upstream in the ruleset-->

--- a/composer.json
+++ b/composer.json
@@ -12,13 +12,13 @@
     "brain/monkey": "^2.6",
     "php-parallel-lint/php-parallel-lint": "^1.3",
     "phpunit/phpunit": "^9.5",
-    "wpengine/wpengine-coding-standards": "dev-develop",
     "yoast/phpunit-polyfills": "^1.0",
     "squizlabs/php_codesniffer": "^3.7",
     "phpstan/phpstan": "^1.10",
     "phpstan/extension-installer": "^1.3",
     "szepeviktor/phpstan-wordpress": "^1.3",
     "axepress/wp-graphql-stubs": "^1.14",
+		"axepress/wp-graphql-cs": "^1.0.0-beta",
     "roave/security-advisories": "dev-latest"
   },
   "scripts": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "f2cc12698747b8c0bb244875cc1fed0b",
+    "content-hash": "5743ef1e8bbc9bfc0eb62e57b6799281",
     "packages": [
         {
             "name": "imangazaliev/didom",
@@ -107,6 +107,118 @@
                 "source": "https://github.com/antecedent/patchwork/tree/2.1.25"
             },
             "time": "2023-02-19T12:51:24+00:00"
+        },
+        {
+            "name": "automattic/vipwpcs",
+            "version": "2.3.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Automattic/VIP-Coding-Standards.git",
+                "reference": "6cd0a6a82bc0ac988dbf9d6a7c2e293dc8ac640b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Automattic/VIP-Coding-Standards/zipball/6cd0a6a82bc0ac988dbf9d6a7c2e293dc8ac640b",
+                "reference": "6cd0a6a82bc0ac988dbf9d6a7c2e293dc8ac640b",
+                "shasum": ""
+            },
+            "require": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.4.1 || ^0.5 || ^0.6.2 || ^0.7",
+                "php": ">=5.4",
+                "sirbrillig/phpcs-variable-analysis": "^2.11.1",
+                "squizlabs/php_codesniffer": "^3.5.5",
+                "wp-coding-standards/wpcs": "^2.3"
+            },
+            "require-dev": {
+                "php-parallel-lint/php-console-highlighter": "^0.5",
+                "php-parallel-lint/php-parallel-lint": "^1.0",
+                "phpcompatibility/php-compatibility": "^9",
+                "phpcsstandards/phpcsdevtools": "^1.0",
+                "phpunit/phpunit": "^4 || ^5 || ^6 || ^7"
+            },
+            "type": "phpcodesniffer-standard",
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Contributors",
+                    "homepage": "https://github.com/Automattic/VIP-Coding-Standards/graphs/contributors"
+                }
+            ],
+            "description": "PHP_CodeSniffer rules (sniffs) to enforce WordPress VIP minimum coding conventions",
+            "keywords": [
+                "phpcs",
+                "standards",
+                "wordpress"
+            ],
+            "support": {
+                "issues": "https://github.com/Automattic/VIP-Coding-Standards/issues",
+                "source": "https://github.com/Automattic/VIP-Coding-Standards",
+                "wiki": "https://github.com/Automattic/VIP-Coding-Standards/wiki"
+            },
+            "time": "2021-09-29T16:20:23+00:00"
+        },
+        {
+            "name": "axepress/wp-graphql-cs",
+            "version": "1.0.0-beta.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/AxeWP/WPGraphQL-Coding-Standards.git",
+                "reference": "e45e4d5eb627c6a7add20c2ebf8d337febdf499d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/AxeWP/WPGraphQL-Coding-Standards/zipball/e45e4d5eb627c6a7add20c2ebf8d337febdf499d",
+                "reference": "e45e4d5eb627c6a7add20c2ebf8d337febdf499d",
+                "shasum": ""
+            },
+            "require": {
+                "automattic/vipwpcs": "^2.3",
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.6.2 || ^0.7 || ^1.0",
+                "php": ">=7.2",
+                "phpcompatibility/phpcompatibility-wp": "^2.1",
+                "slevomat/coding-standard": "^8.12",
+                "squizlabs/php_codesniffer": "^3.7.1"
+            },
+            "require-dev": {
+                "php-parallel-lint/php-console-highlighter": "^1.0.0",
+                "php-parallel-lint/php-parallel-lint": "^1.3.2",
+                "phpcompatibility/php-compatibility": "^9",
+                "phpcsstandards/phpcsdevtools": "^1.0",
+                "phpunit/phpunit": "^8.5 || ^9"
+            },
+            "type": "phpcodesniffer-standard",
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "AxePress Development",
+                    "email": "support@axepress.dev",
+                    "homepage": "https://axepress.dev"
+                },
+                {
+                    "name": "David Levine",
+                    "role": "Developer"
+                }
+            ],
+            "description": "PHP_CodeSniffer rules (sniffs) for the WPGraphQL ecosystem.",
+            "keywords": [
+                "phpcs",
+                "standards",
+                "static analysis",
+                "wordpress",
+                "wpcs",
+                "wpgraphql"
+            ],
+            "support": {
+                "issues": "https://github.com/AxeWP/WPGraphQL-Coding-Standards/issues",
+                "source": "https://github.com/AxeWP/WPGraphQL-Coding-Standards"
+            },
+            "time": "2023-06-17T14:52:55+00:00"
         },
         {
             "name": "axepress/wp-graphql-stubs",
@@ -1000,143 +1112,6 @@
             "time": "2022-10-24T09:00:36+00:00"
         },
         {
-            "name": "phpcsstandards/phpcsextra",
-            "version": "1.0.3",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/PHPCSStandards/PHPCSExtra.git",
-                "reference": "7029c051cd310e2e17c6caea3429bfbe290c41ae"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/PHPCSStandards/PHPCSExtra/zipball/7029c051cd310e2e17c6caea3429bfbe290c41ae",
-                "reference": "7029c051cd310e2e17c6caea3429bfbe290c41ae",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.4",
-                "phpcsstandards/phpcsutils": "^1.0",
-                "squizlabs/php_codesniffer": "^3.7.1"
-            },
-            "require-dev": {
-                "php-parallel-lint/php-console-highlighter": "^1.0",
-                "php-parallel-lint/php-parallel-lint": "^1.3.2",
-                "phpcsstandards/phpcsdevcs": "^1.1.5",
-                "phpcsstandards/phpcsdevtools": "^1.2.0",
-                "phpunit/phpunit": "^4.5 || ^5.0 || ^6.0 || ^7.0"
-            },
-            "type": "phpcodesniffer-standard",
-            "extra": {
-                "branch-alias": {
-                    "dev-stable": "1.x-dev",
-                    "dev-develop": "1.x-dev"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "LGPL-3.0-or-later"
-            ],
-            "authors": [
-                {
-                    "name": "Juliette Reinders Folmer",
-                    "homepage": "https://github.com/jrfnl",
-                    "role": "lead"
-                },
-                {
-                    "name": "Contributors",
-                    "homepage": "https://github.com/PHPCSStandards/PHPCSExtra/graphs/contributors"
-                }
-            ],
-            "description": "A collection of sniffs and standards for use with PHP_CodeSniffer.",
-            "keywords": [
-                "PHP_CodeSniffer",
-                "phpcbf",
-                "phpcodesniffer-standard",
-                "phpcs",
-                "standards",
-                "static analysis"
-            ],
-            "support": {
-                "issues": "https://github.com/PHPCSStandards/PHPCSExtra/issues",
-                "source": "https://github.com/PHPCSStandards/PHPCSExtra"
-            },
-            "time": "2023-03-28T17:48:27+00:00"
-        },
-        {
-            "name": "phpcsstandards/phpcsutils",
-            "version": "1.0.5",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/PHPCSStandards/PHPCSUtils.git",
-                "reference": "0cfef5193e68e8ff179333d8ae937db62939b656"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/PHPCSStandards/PHPCSUtils/zipball/0cfef5193e68e8ff179333d8ae937db62939b656",
-                "reference": "0cfef5193e68e8ff179333d8ae937db62939b656",
-                "shasum": ""
-            },
-            "require": {
-                "dealerdirect/phpcodesniffer-composer-installer": "^0.4.1 || ^0.5 || ^0.6.2 || ^0.7 || ^1.0",
-                "php": ">=5.4",
-                "squizlabs/php_codesniffer": "^3.7.1 || 4.0.x-dev@dev"
-            },
-            "require-dev": {
-                "ext-filter": "*",
-                "php-parallel-lint/php-console-highlighter": "^1.0",
-                "php-parallel-lint/php-parallel-lint": "^1.3.2",
-                "phpcsstandards/phpcsdevcs": "^1.1.3",
-                "phpunit/phpunit": "^4.8.36 || ^5.7.21 || ^6.0 || ^7.0 || ^8.0 || ^9.3",
-                "yoast/phpunit-polyfills": "^1.0.1"
-            },
-            "type": "phpcodesniffer-standard",
-            "extra": {
-                "branch-alias": {
-                    "dev-stable": "1.x-dev",
-                    "dev-develop": "1.x-dev"
-                }
-            },
-            "autoload": {
-                "classmap": [
-                    "PHPCSUtils/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "LGPL-3.0-or-later"
-            ],
-            "authors": [
-                {
-                    "name": "Juliette Reinders Folmer",
-                    "homepage": "https://github.com/jrfnl",
-                    "role": "lead"
-                },
-                {
-                    "name": "Contributors",
-                    "homepage": "https://github.com/PHPCSStandards/PHPCSUtils/graphs/contributors"
-                }
-            ],
-            "description": "A suite of utility functions for use with PHP_CodeSniffer",
-            "homepage": "https://phpcsutils.com/",
-            "keywords": [
-                "PHP_CodeSniffer",
-                "phpcbf",
-                "phpcodesniffer-standard",
-                "phpcs",
-                "phpcs3",
-                "standards",
-                "static analysis",
-                "tokens",
-                "utility"
-            ],
-            "support": {
-                "docs": "https://phpcsutils.com/",
-                "issues": "https://github.com/PHPCSStandards/PHPCSUtils/issues",
-                "source": "https://github.com/PHPCSStandards/PHPCSUtils"
-            },
-            "time": "2023-04-17T16:27:27+00:00"
-        },
-        {
             "name": "phpstan/extension-installer",
             "version": "1.3.0",
             "source": {
@@ -1184,6 +1159,53 @@
                 "source": "https://github.com/phpstan/extension-installer/tree/1.3.0"
             },
             "time": "2023-04-18T13:08:02+00:00"
+        },
+        {
+            "name": "phpstan/phpdoc-parser",
+            "version": "1.22.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpstan/phpdoc-parser.git",
+                "reference": "65c39594fbd8c67abfc68bb323f86447bab79cc0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpstan/phpdoc-parser/zipball/65c39594fbd8c67abfc68bb323f86447bab79cc0",
+                "reference": "65c39594fbd8c67abfc68bb323f86447bab79cc0",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2 || ^8.0"
+            },
+            "require-dev": {
+                "doctrine/annotations": "^2.0",
+                "nikic/php-parser": "^4.15",
+                "php-parallel-lint/php-parallel-lint": "^1.2",
+                "phpstan/extension-installer": "^1.0",
+                "phpstan/phpstan": "^1.5",
+                "phpstan/phpstan-phpunit": "^1.1",
+                "phpstan/phpstan-strict-rules": "^1.0",
+                "phpunit/phpunit": "^9.5",
+                "symfony/process": "^5.2"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "PHPStan\\PhpDocParser\\": [
+                        "src/"
+                    ]
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "PHPDoc parser with support for nullable, intersection and generic types",
+            "support": {
+                "issues": "https://github.com/phpstan/phpdoc-parser/issues",
+                "source": "https://github.com/phpstan/phpdoc-parser/tree/1.22.1"
+            },
+            "time": "2023-06-29T20:46:06+00:00"
         },
         {
             "name": "phpstan/phpstan",
@@ -3242,6 +3264,129 @@
             "time": "2020-09-28T06:39:44+00:00"
         },
         {
+            "name": "sirbrillig/phpcs-variable-analysis",
+            "version": "v2.11.16",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sirbrillig/phpcs-variable-analysis.git",
+                "reference": "dc5582dc5a93a235557af73e523c389aac9a8e88"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sirbrillig/phpcs-variable-analysis/zipball/dc5582dc5a93a235557af73e523c389aac9a8e88",
+                "reference": "dc5582dc5a93a235557af73e523c389aac9a8e88",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.4.0",
+                "squizlabs/php_codesniffer": "^3.5.6"
+            },
+            "require-dev": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.7 || ^1.0",
+                "phpcsstandards/phpcsdevcs": "^1.1",
+                "phpstan/phpstan": "^1.7",
+                "phpunit/phpunit": "^4.8.36 || ^5.7.21 || ^6.5 || ^7.0 || ^8.0 || ^9.0",
+                "sirbrillig/phpcs-import-detection": "^1.1",
+                "vimeo/psalm": "^0.2 || ^0.3 || ^1.1 || ^4.24 || ^5.0@beta"
+            },
+            "type": "phpcodesniffer-standard",
+            "autoload": {
+                "psr-4": {
+                    "VariableAnalysis\\": "VariableAnalysis/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-2-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sam Graham",
+                    "email": "php-codesniffer-variableanalysis@illusori.co.uk"
+                },
+                {
+                    "name": "Payton Swick",
+                    "email": "payton@foolord.com"
+                }
+            ],
+            "description": "A PHPCS sniff to detect problems with variables.",
+            "keywords": [
+                "phpcs",
+                "static analysis"
+            ],
+            "support": {
+                "issues": "https://github.com/sirbrillig/phpcs-variable-analysis/issues",
+                "source": "https://github.com/sirbrillig/phpcs-variable-analysis",
+                "wiki": "https://github.com/sirbrillig/phpcs-variable-analysis/wiki"
+            },
+            "time": "2023-03-31T16:46:32+00:00"
+        },
+        {
+            "name": "slevomat/coding-standard",
+            "version": "8.13.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/slevomat/coding-standard.git",
+                "reference": "a13c15e20f2d307a1ca8dec5313ec462a4466470"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/slevomat/coding-standard/zipball/a13c15e20f2d307a1ca8dec5313ec462a4466470",
+                "reference": "a13c15e20f2d307a1ca8dec5313ec462a4466470",
+                "shasum": ""
+            },
+            "require": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.6.2 || ^0.7 || ^1.0",
+                "php": "^7.2 || ^8.0",
+                "phpstan/phpdoc-parser": "^1.22.0",
+                "squizlabs/php_codesniffer": "^3.7.1"
+            },
+            "require-dev": {
+                "phing/phing": "2.17.4",
+                "php-parallel-lint/php-parallel-lint": "1.3.2",
+                "phpstan/phpstan": "1.10.21",
+                "phpstan/phpstan-deprecation-rules": "1.1.3",
+                "phpstan/phpstan-phpunit": "1.3.13",
+                "phpstan/phpstan-strict-rules": "1.5.1",
+                "phpunit/phpunit": "7.5.20|8.5.21|9.6.8|10.2.2"
+            },
+            "type": "phpcodesniffer-standard",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "8.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "SlevomatCodingStandard\\": "SlevomatCodingStandard/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Slevomat Coding Standard for PHP_CodeSniffer complements Consistence Coding Standard by providing sniffs with additional checks.",
+            "keywords": [
+                "dev",
+                "phpcs"
+            ],
+            "support": {
+                "issues": "https://github.com/slevomat/coding-standard/issues",
+                "source": "https://github.com/slevomat/coding-standard/tree/8.13.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/kukulich",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/slevomat/coding-standard",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2023-06-25T12:52:34+00:00"
+        },
+        {
             "name": "squizlabs/php_codesniffer",
             "version": "3.7.2",
             "source": {
@@ -3488,36 +3633,31 @@
         },
         {
             "name": "wp-coding-standards/wpcs",
-            "version": "dev-develop",
+            "version": "2.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/WordPress/WordPress-Coding-Standards.git",
-                "reference": "fca9d9ef2dcd042658ccb9df16552f5048e7bb04"
+                "reference": "7da1894633f168fe244afc6de00d141f27517b62"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/WordPress/WordPress-Coding-Standards/zipball/fca9d9ef2dcd042658ccb9df16552f5048e7bb04",
-                "reference": "fca9d9ef2dcd042658ccb9df16552f5048e7bb04",
+                "url": "https://api.github.com/repos/WordPress/WordPress-Coding-Standards/zipball/7da1894633f168fe244afc6de00d141f27517b62",
+                "reference": "7da1894633f168fe244afc6de00d141f27517b62",
                 "shasum": ""
             },
             "require": {
-                "ext-filter": "*",
                 "php": ">=5.4",
-                "phpcsstandards/phpcsextra": "^1.0",
-                "phpcsstandards/phpcsutils": "^1.0.5",
-                "squizlabs/php_codesniffer": "^3.7.2"
+                "squizlabs/php_codesniffer": "^3.3.1"
             },
             "require-dev": {
-                "php-parallel-lint/php-console-highlighter": "^1.0.0",
-                "php-parallel-lint/php-parallel-lint": "^1.3.2",
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.5 || ^0.6",
                 "phpcompatibility/php-compatibility": "^9.0",
-                "phpcsstandards/phpcsdevtools": "^1.2.0",
+                "phpcsstandards/phpcsdevtools": "^1.0",
                 "phpunit/phpunit": "^4.0 || ^5.0 || ^6.0 || ^7.0"
             },
             "suggest": {
-                "ext-mbstring": "For improved results"
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.6 || This Composer plugin will sort out the PHPCS 'installed_paths' automatically."
             },
-            "default-branch": true,
             "type": "phpcodesniffer-standard",
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -3533,7 +3673,6 @@
             "keywords": [
                 "phpcs",
                 "standards",
-                "static analysis",
                 "wordpress"
             ],
             "support": {
@@ -3541,57 +3680,7 @@
                 "source": "https://github.com/WordPress/WordPress-Coding-Standards",
                 "wiki": "https://github.com/WordPress/WordPress-Coding-Standards/wiki"
             },
-            "time": "2023-05-01T08:34:06+00:00"
-        },
-        {
-            "name": "wpengine/wpengine-coding-standards",
-            "version": "dev-develop",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/wpengine/wpengine-coding-standards.git",
-                "reference": "65309cd239651fa05c717f8225a4c2b1957a6c43"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/wpengine/wpengine-coding-standards/zipball/65309cd239651fa05c717f8225a4c2b1957a6c43",
-                "reference": "65309cd239651fa05c717f8225a4c2b1957a6c43",
-                "shasum": ""
-            },
-            "require": {
-                "dealerdirect/phpcodesniffer-composer-installer": "^0.7.0",
-                "php": ">=5.4",
-                "phpcompatibility/phpcompatibility-wp": "^2.1.3",
-                "squizlabs/php_codesniffer": "^3.5",
-                "wp-coding-standards/wpcs": "dev-develop"
-            },
-            "bin": [
-                "bin/wpecs",
-                "bin/wpecbf"
-            ],
-            "type": "phpcodesniffer-standard",
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Contributors",
-                    "homepage": "https://github.com/wpengine/wpengine-coding-standards/graphs/contributors"
-                }
-            ],
-            "description": "PHP_CodeSniffer rules (sniffs) to enforce WP Engine coding conventions",
-            "keywords": [
-                "phpcs",
-                "standards",
-                "wordpress",
-                "wp-engine",
-                "wpecs"
-            ],
-            "support": {
-                "issues": "https://github.com/wpengine/wpengine-coding-standards/issues",
-                "source": "https://github.com/wpengine/wpengine-coding-standards"
-            },
-            "time": "2022-11-10T20:44:46+00:00"
+            "time": "2020-05-13T23:57:56+00:00"
         },
         {
             "name": "yoast/phpunit-polyfills",
@@ -3657,7 +3746,6 @@
     "aliases": [],
     "minimum-stability": "dev",
     "stability-flags": {
-        "wpengine/wpengine-coding-standards": 20,
         "roave/security-advisories": 20
     },
     "prefer-stable": true,

--- a/includes/Blocks/Block.php
+++ b/includes/Blocks/Block.php
@@ -94,20 +94,20 @@ class Block {
 			$block_attribute_type_name = $this->type_name . 'Attributes';
 			register_graphql_object_type(
 				$block_attribute_type_name,
-				array(
+				[
 					'description' => sprintf(
 						// translators: %s is the block type name.
 						__( 'Attributes of the %s Block Type', 'wp-graphql-content-blocks' ),
 						$this->type_name
 					),
 					'fields'      => $block_attribute_fields,
-				)
+				]
 			);
 
 			register_graphql_field(
 				$this->type_name,
 				'attributes',
-				array(
+				[
 					'type'        => $block_attribute_type_name,
 					'description' => sprintf(
 						// translators: %s is the block type name.
@@ -117,7 +117,7 @@ class Block {
 					'resolve'     => function ( $block ) {
 						return $block;
 					},
-				)
+				]
 			);
 		}//end if
 	}
@@ -135,7 +135,7 @@ class Block {
 	 * @param ?array $block_attributes The block attributes.
 	 */
 	private function get_block_attribute_fields( ?array $block_attributes ): array {
-		$block_attribute_fields = array();
+		$block_attribute_fields = [];
 
 		// Bail early if no attributes are defined.
 		if ( null === $block_attributes ) {
@@ -174,7 +174,7 @@ class Block {
 			}
 
 			// Create the field config.
-			$block_attribute_fields[ Utils::format_field_name( $attribute_name ) ] = array(
+			$block_attribute_fields[ Utils::format_field_name( $attribute_name ) ] = [
 				'type'        => $graphql_type,
 				'description' => sprintf(
 					// translators: %1$s is the attribute name, %2$s is the block name.
@@ -185,7 +185,7 @@ class Block {
 				'resolve'     => function ( $block ) use ( $attribute_name, $attribute_config ) {
 					return $this->resolve_block_attributes( $block, $attribute_name, $attribute_config );
 				},
-			);
+			];
 		}//end foreach
 
 		return $block_attribute_fields;
@@ -211,20 +211,20 @@ class Block {
 		 */
 		register_graphql_object_type(
 			$this->type_name,
-			array(
+			[
 				'description'     => __( 'A block used for editing the site', 'wp-graphql-content-blocks' ),
 				'interfaces'      => $this->get_block_interfaces(),
 				'eagerlyLoadType' => true,
-				'fields'          => array(
-					'name' => array(
+				'fields'          => [
+					'name' => [
 						'type'        => 'String',
 						'description' => __( 'The name of the block', 'wp-graphql-content-blocks' ),
 						'resolve'     => function ( $block ) {
 							return $this->resolve( $block );
 						},
-					),
-				),
-			)
+					],
+				],
+			]
 		);
 	}
 

--- a/includes/Blocks/Block.php
+++ b/includes/Blocks/Block.php
@@ -114,7 +114,7 @@ class Block {
 						__( 'Attributes of the %s Block Type', 'wp-graphql-content-blocks' ),
 						$this->type_name
 					),
-					'resolve'     => function ( $block ) {
+					'resolve'     => static function ( $block ) {
 						return $block;
 					},
 				]

--- a/includes/Blocks/Block.php
+++ b/includes/Blocks/Block.php
@@ -7,13 +7,13 @@
 
 namespace WPGraphQL\ContentBlocks\Blocks;
 
-use WP_Block_Type;
+use WPGraphQL\ContentBlocks\Field\BlockSupports\Anchor;
 use WPGraphQL\ContentBlocks\Registry\Registry;
+use WPGraphQL\ContentBlocks\Type\Scalar\Scalar;
 use WPGraphQL\ContentBlocks\Utilities\DOMHelpers;
 use WPGraphQL\ContentBlocks\Utilities\WPGraphQLHelpers;
-use WPGraphQL\ContentBlocks\Type\Scalar\Scalar;
-use WPGraphQL\ContentBlocks\Field\BlockSupports\Anchor;
 use WPGraphQL\Utils\Utils;
+use WP_Block_Type;
 
 /**
  * Class Block
@@ -202,8 +202,6 @@ class Block {
 
 	/**
 	 * Register the Type for the block
-	 *
-	 * @return void
 	 */
 	private function register_type(): void {
 		/**

--- a/includes/Blocks/CoreButton.php
+++ b/includes/Blocks/CoreButton.php
@@ -16,18 +16,18 @@ class CoreButton extends Block {
 	 *
 	 * @var array|null
 	 */
-	protected ?array $additional_block_attributes = array(
-		'cssClassName'  => array(
+	protected ?array $additional_block_attributes = [
+		'cssClassName'  => [
 			'type'      => 'string',
 			'selector'  => 'div',
 			'source'    => 'attribute',
 			'attribute' => 'class',
-		),
-		'linkClassName' => array(
+		],
+		'linkClassName' => [
 			'type'      => 'string',
 			'selector'  => 'a',
 			'source'    => 'attribute',
 			'attribute' => 'class',
-		),
-	);
+		],
+	];
 }

--- a/includes/Blocks/CoreButtons.php
+++ b/includes/Blocks/CoreButtons.php
@@ -16,12 +16,12 @@ class CoreButtons extends Block {
 	 *
 	 * @var array|null
 	 */
-	protected ?array $additional_block_attributes = array(
-		'cssClassName' => array(
+	protected ?array $additional_block_attributes = [
+		'cssClassName' => [
 			'type'      => 'string',
 			'selector'  => 'div',
 			'source'    => 'attribute',
 			'attribute' => 'class',
-		),
-	);
+		],
+	];
 }

--- a/includes/Blocks/CoreCode.php
+++ b/includes/Blocks/CoreCode.php
@@ -16,12 +16,12 @@ class CoreCode extends Block {
 	 *
 	 * @var array|null
 	 */
-	protected ?array $additional_block_attributes = array(
-		'cssClassName' => array(
+	protected ?array $additional_block_attributes = [
+		'cssClassName' => [
 			'type'      => 'string',
 			'selector'  => 'pre',
 			'source'    => 'attribute',
 			'attribute' => 'class',
-		),
-	);
+		],
+	];
 }

--- a/includes/Blocks/CoreColumn.php
+++ b/includes/Blocks/CoreColumn.php
@@ -16,12 +16,12 @@ class CoreColumn extends Block {
 	 *
 	 * @var array|null
 	 */
-	protected ?array $additional_block_attributes = array(
-		'cssClassName' => array(
+	protected ?array $additional_block_attributes = [
+		'cssClassName' => [
 			'type'      => 'string',
 			'selector'  => 'div',
 			'source'    => 'attribute',
 			'attribute' => 'class',
-		),
-	);
+		],
+	];
 }

--- a/includes/Blocks/CoreColumns.php
+++ b/includes/Blocks/CoreColumns.php
@@ -16,12 +16,12 @@ class CoreColumns extends Block {
 	 *
 	 * @var array|null
 	 */
-	protected ?array $additional_block_attributes = array(
-		'cssClassName' => array(
+	protected ?array $additional_block_attributes = [
+		'cssClassName' => [
 			'type'      => 'string',
 			'selector'  => 'div',
 			'source'    => 'attribute',
 			'attribute' => 'class',
-		),
-	);
+		],
+	];
 }

--- a/includes/Blocks/CoreHeading.php
+++ b/includes/Blocks/CoreHeading.php
@@ -16,12 +16,12 @@ class CoreHeading extends Block {
 	 *
 	 * @var array|null
 	 */
-	protected ?array $additional_block_attributes = array(
-		'cssClassName' => array(
+	protected ?array $additional_block_attributes = [
+		'cssClassName' => [
 			'type'      => 'string',
 			'selector'  => 'h1, h2, h3, h4, h5, h6',
 			'source'    => 'attribute',
 			'attribute' => 'class',
-		),
-	);
+		],
+	];
 }

--- a/includes/Blocks/CoreImage.php
+++ b/includes/Blocks/CoreImage.php
@@ -16,18 +16,18 @@ class CoreImage extends Block {
 	 *
 	 * @var array|null
 	 */
-	protected ?array $additional_block_attributes = array(
-		'cssClassName' => array(
+	protected ?array $additional_block_attributes = [
+		'cssClassName' => [
 			'type'      => 'string',
 			'selector'  => 'figure',
 			'source'    => 'attribute',
 			'attribute' => 'class',
-		),
-		'src'          => array(
+		],
+		'src'          => [
 			'type'      => 'string',
 			'selector'  => 'img',
 			'source'    => 'attribute',
 			'attribute' => 'src',
-		),
-	);
+		],
+	];
 }

--- a/includes/Blocks/CoreList.php
+++ b/includes/Blocks/CoreList.php
@@ -16,12 +16,12 @@ class CoreList extends Block {
 	 *
 	 * @var array|null
 	 */
-	protected ?array $additional_block_attributes = array(
-		'cssClassName' => array(
+	protected ?array $additional_block_attributes = [
+		'cssClassName' => [
 			'type'      => 'string',
 			'selector'  => 'ul,ol',
 			'source'    => 'attribute',
 			'attribute' => 'class',
-		),
-	);
+		],
+	];
 }

--- a/includes/Blocks/CoreParagraph.php
+++ b/includes/Blocks/CoreParagraph.php
@@ -16,17 +16,17 @@ class CoreParagraph extends Block {
 	 *
 	 * @var array|null
 	 */
-	protected ?array $additional_block_attributes = array(
-		'cssClassName' => array(
+	protected ?array $additional_block_attributes = [
+		'cssClassName' => [
 			'type'      => 'string',
 			'selector'  => 'p',
 			'source'    => 'attribute',
 			'attribute' => 'class',
-		),
-		'content'      => array(
+		],
+		'content'      => [
 			'type'     => 'string',
 			'selector' => 'p',
 			'source'   => 'html',
-		),
-	);
+		],
+	];
 }

--- a/includes/Blocks/CoreQuote.php
+++ b/includes/Blocks/CoreQuote.php
@@ -16,12 +16,12 @@ class CoreQuote extends Block {
 	 *
 	 * @var array|null
 	 */
-	protected ?array $additional_block_attributes = array(
-		'cssClassName' => array(
+	protected ?array $additional_block_attributes = [
+		'cssClassName' => [
 			'type'      => 'string',
 			'selector'  => 'blockquote',
 			'source'    => 'attribute',
 			'attribute' => 'class',
-		),
-	);
+		],
+	];
 }

--- a/includes/Blocks/CoreSeparator.php
+++ b/includes/Blocks/CoreSeparator.php
@@ -16,12 +16,12 @@ class CoreSeparator extends Block {
 	 *
 	 * @var array|null
 	 */
-	protected ?array $additional_block_attributes = array(
-		'cssClassName' => array(
+	protected ?array $additional_block_attributes = [
+		'cssClassName' => [
 			'type'      => 'string',
 			'selector'  => 'hr',
 			'source'    => 'attribute',
 			'attribute' => 'class',
-		),
-	);
+		],
+	];
 }

--- a/includes/Data/ContentBlocksResolver.php
+++ b/includes/Data/ContentBlocksResolver.php
@@ -20,7 +20,7 @@ final class ContentBlocksResolver {
 	 * @param array $args GraphQL query args to pass to the connection resolver.
 	 * @param array $allowed_block_names The list of allowed block names to filter.
 	 */
-	public static function resolve_content_blocks( $node, $args, $allowed_block_names = array() ): array {
+	public static function resolve_content_blocks( $node, $args, $allowed_block_names = [] ): array {
 		$content = null;
 		if ( $node instanceof Post ) {
 
@@ -45,17 +45,17 @@ final class ContentBlocksResolver {
 		$content = apply_filters( 'wpgraphql_content_blocks_resolver_content', $content, $node, $args );
 
 		if ( empty( $content ) ) {
-			return array();
+			return [];
 		}
 
 		// Parse the blocks from HTML comments to an array of blocks
 		$parsed_blocks = parse_blocks( $content );
 		if ( empty( $parsed_blocks ) ) {
-			return array();
+			return [];
 		}
 
 		// Resolve reusable blocks - replaces "core/block" with the corresponding block(s) from the reusable ref ID
-		$new_parsed_blocks = array();
+		$new_parsed_blocks = [];
 		foreach ( $parsed_blocks as $block ) {
 			if ( 'core/block' === $block['blockName'] && $block['attrs']['ref'] ) {
 				$reusable_blocks = parse_blocks( get_post( $block['attrs']['ref'] )->post_content );
@@ -122,7 +122,7 @@ final class ContentBlocksResolver {
 	 * @param array $blocks A list of blocks to flatten.
 	 */
 	private static function flatten_block_list( $blocks ): array {
-		$result = array();
+		$result = [];
 		foreach ( $blocks as $block ) {
 			$result = array_merge( $result, self::flatten_inner_blocks( $block ) );
 		}
@@ -135,7 +135,7 @@ final class ContentBlocksResolver {
 	 * @param mixed $block A block.
 	 */
 	private static function flatten_inner_blocks( $block ): array {
-		$result            = array();
+		$result            = [];
 		$block['clientId'] = isset( $block['clientId'] ) ? $block['clientId'] : uniqid();
 		array_push( $result, $block );
 		foreach ( $block['innerBlocks'] as $child ) {

--- a/includes/Data/ContentBlocksResolver.php
+++ b/includes/Data/ContentBlocksResolver.php
@@ -99,7 +99,7 @@ final class ContentBlocksResolver {
 		);
 
 		// Flatten block list here if requested or if 'flat' value is not selected (default)
-		if ( ! isset( $args['flat'] ) || 'true' == $args['flat'] ) { // phpcs:ignore Universal.Operators.StrictComparisons.LooseEqual
+		if ( ! isset( $args['flat'] ) || 'true' == $args['flat'] ) { // phpcs:ignore WordPress.PHP.StrictComparisons.LooseComparison
 			$parsed_blocks = self::flatten_block_list( $parsed_blocks );
 		}
 

--- a/includes/Data/ContentBlocksResolver.php
+++ b/includes/Data/ContentBlocksResolver.php
@@ -72,7 +72,7 @@ final class ContentBlocksResolver {
 		// 1st Level filtering of blocks that are empty
 		$parsed_blocks = array_filter(
 			$parsed_blocks,
-			function ( $parsed_block ) {
+			static function ( $parsed_block ) {
 				if ( ! empty( $parsed_block['blockName'] ) ) {
 					return true;
 				}
@@ -86,7 +86,7 @@ final class ContentBlocksResolver {
 
 		// 1st Level assigning of unique id's and missing blockNames
 		$parsed_blocks = array_map(
-			function ( $parsed_block ) {
+			static function ( $parsed_block ) {
 				$parsed_block['clientId'] = uniqid();
 				// Since Gutenberg assigns an empty blockName for Classic block
 				// we define the name here
@@ -107,7 +107,7 @@ final class ContentBlocksResolver {
 		if ( ! empty( $allowed_block_names ) ) {
 			$parsed_blocks = array_filter(
 				$parsed_blocks,
-				function ( $parsed_block ) use ( $allowed_block_names ) {
+				static function ( $parsed_block ) use ( $allowed_block_names ) {
 					return in_array( $parsed_block['blockName'], $allowed_block_names, true );
 				},
 				ARRAY_FILTER_USE_BOTH

--- a/includes/Field/BlockSupports/Anchor.php
+++ b/includes/Field/BlockSupports/Anchor.php
@@ -21,22 +21,22 @@ class Anchor {
 	public static function register(): void {
 		register_graphql_interface_type(
 			'BlockWithSupportsAnchor',
-			array(
+			[
 				'description' => __( 'Block that supports Anchor field', 'wp-graphql-content-blocks' ),
-				'fields'      => array(
-					'anchor' => array(
+				'fields'      => [
+					'anchor' => [
 						'type'        => 'string',
 						'description' => __( 'The anchor field for the block.', 'wp-graphql-content-blocks' ),
 						'resolve'     => function ( $block ) {
-							$rendered_block   = wp_unslash( render_block( $block ) );
+							$rendered_block = wp_unslash( render_block( $block ) );
 							if ( empty( $rendered_block ) ) {
 								return null;
 							}
 							return DOMHelpers::parseFirstNodeAttribute( $rendered_block, 'id' );
 						},
-					),
-				),
-			)
+					],
+				],
+			]
 		);
 	}
 
@@ -48,8 +48,8 @@ class Anchor {
 	 */
 	public static function register_to_block( \WP_Block_Type $block_spec ): void {
 		if ( isset( $block_spec->supports['anchor'] ) && true === $block_spec->supports['anchor'] ) {
-			register_graphql_interfaces_to_types( 'BlockWithSupportsAnchor', array( WPGraphQLHelpers::format_type_name( $block_spec->name ) . 'Attributes' ) );
-			register_graphql_interfaces_to_types( 'BlockWithSupportsAnchor', array( WPGraphQLHelpers::format_type_name( $block_spec->name ) ) );
+			register_graphql_interfaces_to_types( 'BlockWithSupportsAnchor', [ WPGraphQLHelpers::format_type_name( $block_spec->name ) . 'Attributes' ] );
+			register_graphql_interfaces_to_types( 'BlockWithSupportsAnchor', [ WPGraphQLHelpers::format_type_name( $block_spec->name ) ] );
 		}
 	}
 }

--- a/includes/Field/BlockSupports/Anchor.php
+++ b/includes/Field/BlockSupports/Anchor.php
@@ -7,7 +7,6 @@
 
 namespace WPGraphQL\ContentBlocks\Field\BlockSupports;
 
-use WP_Block_Type;
 use WPGraphQL\ContentBlocks\Utilities\DOMHelpers;
 use WPGraphQL\ContentBlocks\Utilities\WPGraphQLHelpers;
 
@@ -27,7 +26,7 @@ class Anchor {
 					'anchor' => [
 						'type'        => 'string',
 						'description' => __( 'The anchor field for the block.', 'wp-graphql-content-blocks' ),
-						'resolve'     => function ( $block ) {
+						'resolve'     => static function ( $block ) {
 							$rendered_block = wp_unslash( render_block( $block ) );
 							if ( empty( $rendered_block ) ) {
 								return null;

--- a/includes/Field/BlockSupports/Anchor.php
+++ b/includes/Field/BlockSupports/Anchor.php
@@ -43,7 +43,6 @@ class Anchor {
 	 * Registers an Anchor field on a block if it supports it.
 	 *
 	 * @param \WP_Block_Type $block_spec The block type to register the anchor field against.
-	 * @return void
 	 */
 	public static function register_to_block( \WP_Block_Type $block_spec ): void {
 		if ( isset( $block_spec->supports['anchor'] ) && true === $block_spec->supports['anchor'] ) {

--- a/includes/Registry/Registry.php
+++ b/includes/Registry/Registry.php
@@ -160,7 +160,7 @@ final class Registry {
 		}
 
 		$type_names = array_map(
-			function ( $post_type ) {
+			static function ( $post_type ) {
 				return $post_type->graphql_single_name ?? null;
 			},
 			$supported_post_types

--- a/includes/Registry/Registry.php
+++ b/includes/Registry/Registry.php
@@ -49,7 +49,7 @@ final class Registry {
 	 *
 	 * @var array
 	 */
-	public $block_interfaces = array();
+	public $block_interfaces = [];
 
 	/**
 	 * Registry constructor.
@@ -96,7 +96,7 @@ final class Registry {
 		$block_and_graphql_enabled_post_types = WPHelpers::get_supported_post_types();
 
 		if ( empty( $block_and_graphql_enabled_post_types ) ) {
-			return array();
+			return [];
 		}
 
 		$post_id = -1;
@@ -125,7 +125,7 @@ final class Registry {
 			}
 		}//end foreach
 
-		return ! empty( $this->block_interfaces[ $block_name ] ) ? $this->block_interfaces[ $block_name ] : array();
+		return ! empty( $this->block_interfaces[ $block_name ] ) ? $this->block_interfaces[ $block_name ] : [];
 	}
 
 	/**
@@ -141,7 +141,7 @@ final class Registry {
 		$context_interfaces = $this->get_block_context_interfaces( $block_name );
 
 		// @todo: if blocks need to implement other interfaces (i.e. "BlockSupports" interfaces, that could be handled here as well)
-		return array_merge( array( 'EditorBlock' ), $context_interfaces );
+		return array_merge( [ 'EditorBlock' ], $context_interfaces );
 	}
 
 	/**
@@ -160,12 +160,12 @@ final class Registry {
 		}
 
 		$type_names = array_map(
-			function( $post_type ) {
+			function ( $post_type ) {
 				return $post_type->graphql_single_name ?? null;
 			},
 			$supported_post_types
 		);
-		register_graphql_interfaces_to_types( array( 'NodeWithEditorBlocks' ), $type_names );
+		register_graphql_interfaces_to_types( [ 'NodeWithEditorBlocks' ], $type_names );
 		$post_id = -1;
 		// For each Post type
 		foreach ( $supported_post_types as $post_type ) {
@@ -189,7 +189,7 @@ final class Registry {
 				PostTypeBlockInterface::register_type( $type_name, $supported_blocks_for_post_type );
 
 				// Register the `NodeWith[PostType]Blocks` Interface to the post type
-				register_graphql_interfaces_to_types( array( 'NodeWith' . Utils::format_type_name( $post_type->graphql_single_name ) . 'EditorBlocks' ), array( $type_name ) );
+				register_graphql_interfaces_to_types( [ 'NodeWith' . Utils::format_type_name( $post_type->graphql_single_name ) . 'EditorBlocks' ], [ $type_name ] );
 			}
 		}//end foreach
 	}

--- a/includes/Registry/Registry.php
+++ b/includes/Registry/Registry.php
@@ -7,22 +7,21 @@
 
 namespace WPGraphQL\ContentBlocks\Registry;
 
-use WP_Block_Type;
 use WPGraphQL\ContentBlocks\Blocks\Block;
 use WPGraphQL\ContentBlocks\Field\BlockSupports\Anchor;
-use WPGraphQL\ContentBlocks\Type\Scalar\Scalar;
 use WPGraphQL\ContentBlocks\Type\InterfaceType\EditorBlockInterface;
 use WPGraphQL\ContentBlocks\Type\InterfaceType\PostTypeBlockInterface;
+use WPGraphQL\ContentBlocks\Type\Scalar\Scalar;
 use WPGraphQL\ContentBlocks\Utilities\WPGraphQLHelpers;
 use WPGraphQL\ContentBlocks\Utilities\WPHelpers;
 use WPGraphQL\Registry\TypeRegistry;
 use WPGraphQL\Utils\Utils;
+use WP_Block_Type;
 
 /**
  * Class Registry
  */
 final class Registry {
-
 	/**
 	 * The instance of the WPGraphQL type registry.
 	 *
@@ -64,8 +63,6 @@ final class Registry {
 
 	/**
 	 * Registry init procedure.
-	 *
-	 * @return void
 	 */
 	public function init(): void {
 		$this->register_interface_types();
@@ -146,8 +143,6 @@ final class Registry {
 
 	/**
 	 * Register Interface types to the GraphQL Schema
-	 *
-	 * @return void
 	 */
 	protected function register_interface_types(): void {
 		// First register the NodeWithEditorBlocks interface by default

--- a/includes/Type/InterfaceType/EditorBlockInterface.php
+++ b/includes/Type/InterfaceType/EditorBlockInterface.php
@@ -7,9 +7,9 @@
 
 namespace WPGraphQL\ContentBlocks\Type\InterfaceType;
 
-use WP_Block_Type_Registry;
 use WPGraphQL\ContentBlocks\Data\ContentBlocksResolver;
 use WPGraphQL\ContentBlocks\Utilities\WPGraphQLHelpers;
+use WP_Block_Type_Registry;
 
 /**
  * Class EditorBlockInterface

--- a/includes/Type/InterfaceType/EditorBlockInterface.php
+++ b/includes/Type/InterfaceType/EditorBlockInterface.php
@@ -56,7 +56,7 @@ final class EditorBlockInterface {
 							],
 						],
 						'description' => __( 'List of editor blocks', 'wp-graphql-content-blocks' ),
-						'resolve'     => function ( $node, $args ) {
+						'resolve'     => static function ( $node, $args ) {
 							return ContentBlocksResolver::resolve_content_blocks( $node, $args );
 						},
 					],
@@ -74,14 +74,14 @@ final class EditorBlockInterface {
 					'clientId'                => [
 						'type'        => 'String',
 						'description' => __( 'The id of the Block', 'wp-graphql-content-blocks' ),
-						'resolve'     => function ( $block ) {
+						'resolve'     => static function ( $block ) {
 							return isset( $block['clientId'] ) ? $block['clientId'] : uniqid();
 						},
 					],
 					'parentClientId'          => [
 						'type'        => 'String',
 						'description' => __( 'The parent id of the Block', 'wp-graphql-content-blocks' ),
-						'resolve'     => function ( $block ) {
+						'resolve'     => static function ( $block ) {
 							return isset( $block['parentClientId'] ) ? $block['parentClientId'] : null;
 						},
 					],
@@ -92,21 +92,21 @@ final class EditorBlockInterface {
 					'blockEditorCategoryName' => [
 						'type'        => 'String',
 						'description' => __( 'The name of the category the Block belongs to', 'wp-graphql-content-blocks' ),
-						'resolve'     => function ( $block ) {
+						'resolve'     => static function ( $block ) {
 							return isset( self::get_block( $block )->category ) ? self::get_block( $block )->category : null;
 						},
 					],
 					'isDynamic'               => [
 						'type'        => [ 'non_null' => 'Boolean' ],
 						'description' => __( 'Whether the block is Dynamic (server rendered)', 'wp-graphql-content-blocks' ),
-						'resolve'     => function ( $block ) {
+						'resolve'     => static function ( $block ) {
 							return isset( self::get_block( $block )->render_callback );
 						},
 					],
 					'apiVersion'              => [
 						'type'        => 'Integer',
 						'description' => __( 'The API version of the Gutenberg Block', 'wp-graphql-content-blocks' ),
-						'resolve'     => function ( $block ) {
+						'resolve'     => static function ( $block ) {
 							return isset( self::get_block( $block )->api_version ) && absint( self::get_block( $block )->api_version ) ? absint( self::get_block( $block )->api_version ) : 2;
 						},
 					],
@@ -115,14 +115,14 @@ final class EditorBlockInterface {
 							'list_of' => 'EditorBlock',
 						],
 						'description' => __( 'The inner blocks of the Block', 'wp-graphql-content-blocks' ),
-						'resolve'     => function ( $block ) {
+						'resolve'     => static function ( $block ) {
 							return isset( $block['innerBlocks'] ) && is_array( $block['innerBlocks'] ) ? $block['innerBlocks'] : [];
 						},
 					],
 					'cssClassNames'           => [
 						'type'        => [ 'list_of' => 'String' ],
 						'description' => __( 'CSS Classnames to apply to the block', 'wp-graphql-content-blocks' ),
-						'resolve'     => function ( $block ) {
+						'resolve'     => static function ( $block ) {
 							if ( isset( $block['attrs']['className'] ) ) {
 								return explode( ' ', $block['attrs']['className'] );
 							}
@@ -133,12 +133,12 @@ final class EditorBlockInterface {
 					'renderedHtml'            => [
 						'type'        => 'String',
 						'description' => __( 'The rendered HTML for the block', 'wp-graphql-content-blocks' ),
-						'resolve'     => function ( $block ) {
+						'resolve'     => static function ( $block ) {
 							return render_block( $block );
 						},
 					],
 				],
-				'resolveType'     => function ( $block ) {
+				'resolveType'     => static function ( $block ) {
 					if ( empty( $block['blockName'] ) ) {
 						$block['blockName'] = 'core/freeform';
 					}

--- a/includes/Type/InterfaceType/EditorBlockInterface.php
+++ b/includes/Type/InterfaceType/EditorBlockInterface.php
@@ -42,85 +42,85 @@ final class EditorBlockInterface {
 	public static function register_type(): void {
 		register_graphql_interface_type(
 			'NodeWithEditorBlocks',
-			array(
+			[
 				'description'     => __( 'Node that has content blocks associated with it', 'wp-graphql-content-blocks' ),
 				'eagerlyLoadType' => true,
-				'fields'          => array(
-					'editorBlocks' => array(
-						'type'        => array(
+				'fields'          => [
+					'editorBlocks' => [
+						'type'        => [
 							'list_of' => 'EditorBlock',
-						),
-						'args'        => array(
-							'flat' => array(
+						],
+						'args'        => [
+							'flat' => [
 								'type' => 'Boolean',
-							),
-						),
+							],
+						],
 						'description' => __( 'List of editor blocks', 'wp-graphql-content-blocks' ),
 						'resolve'     => function ( $node, $args ) {
 							return ContentBlocksResolver::resolve_content_blocks( $node, $args );
 						},
-					),
-				),
-			)
+					],
+				],
+			]
 		);
 
 		// Register the EditorBlock Interface
 		register_graphql_interface_type(
 			'EditorBlock',
-			array(
+			[
 				'eagerlyLoadType' => true,
 				'description'     => __( 'Blocks that can be edited to create content and layouts', 'wp-graphql-content-blocks' ),
-				'fields'          => array(
-					'clientId'                => array(
+				'fields'          => [
+					'clientId'                => [
 						'type'        => 'String',
 						'description' => __( 'The id of the Block', 'wp-graphql-content-blocks' ),
 						'resolve'     => function ( $block ) {
 							return isset( $block['clientId'] ) ? $block['clientId'] : uniqid();
 						},
-					),
-					'parentClientId'          => array(
+					],
+					'parentClientId'          => [
 						'type'        => 'String',
 						'description' => __( 'The parent id of the Block', 'wp-graphql-content-blocks' ),
 						'resolve'     => function ( $block ) {
 							return isset( $block['parentClientId'] ) ? $block['parentClientId'] : null;
 						},
-					),
-					'name'                    => array(
+					],
+					'name'                    => [
 						'type'        => 'String',
 						'description' => __( 'The name of the Block', 'wp-graphql-content-blocks' ),
-					),
-					'blockEditorCategoryName' => array(
+					],
+					'blockEditorCategoryName' => [
 						'type'        => 'String',
 						'description' => __( 'The name of the category the Block belongs to', 'wp-graphql-content-blocks' ),
 						'resolve'     => function ( $block ) {
 							return isset( self::get_block( $block )->category ) ? self::get_block( $block )->category : null;
 						},
-					),
-					'isDynamic'               => array(
-						'type'        => array( 'non_null' => 'Boolean' ),
+					],
+					'isDynamic'               => [
+						'type'        => [ 'non_null' => 'Boolean' ],
 						'description' => __( 'Whether the block is Dynamic (server rendered)', 'wp-graphql-content-blocks' ),
 						'resolve'     => function ( $block ) {
 							return isset( self::get_block( $block )->render_callback );
 						},
-					),
-					'apiVersion'              => array(
+					],
+					'apiVersion'              => [
 						'type'        => 'Integer',
 						'description' => __( 'The API version of the Gutenberg Block', 'wp-graphql-content-blocks' ),
 						'resolve'     => function ( $block ) {
 							return isset( self::get_block( $block )->api_version ) && absint( self::get_block( $block )->api_version ) ? absint( self::get_block( $block )->api_version ) : 2;
 						},
-					),
-					'innerBlocks'             => array(
-						'type'        => array(
+					],
+					'innerBlocks'             => [
+						'type'        => [
 							'list_of' => 'EditorBlock',
-						),
+						],
 						'description' => __( 'The inner blocks of the Block', 'wp-graphql-content-blocks' ),
 						'resolve'     => function ( $block ) {
-							return isset( $block['innerBlocks'] ) && is_array( $block['innerBlocks'] ) ? $block['innerBlocks'] : array();
+							return isset( $block['innerBlocks'] ) && is_array( $block['innerBlocks'] ) ? $block['innerBlocks'] : [];
 						},
-					),
-					'cssClassNames'           => array(
-						'type'        => array( 'list_of' => 'String' ),
+					],
+					'cssClassNames'           => [
+						'type'        => [ 'list_of' => 'String' ],
 						'description' => __( 'CSS Classnames to apply to the block', 'wp-graphql-content-blocks' ),
 						'resolve'     => function ( $block ) {
 							if ( isset( $block['attrs']['className'] ) ) {
@@ -129,15 +129,15 @@ final class EditorBlockInterface {
 
 							return null;
 						},
-					),
-					'renderedHtml'            => array(
+					],
+					'renderedHtml'            => [
 						'type'        => 'String',
 						'description' => __( 'The rendered HTML for the block', 'wp-graphql-content-blocks' ),
 						'resolve'     => function ( $block ) {
 							return render_block( $block );
 						},
-					),
-				),
+					],
+				],
 				'resolveType'     => function ( $block ) {
 					if ( empty( $block['blockName'] ) ) {
 						$block['blockName'] = 'core/freeform';
@@ -147,7 +147,7 @@ final class EditorBlockInterface {
 
 					return WPGraphQLHelpers::format_type_name( $type_name );
 				},
-			)
+			]
 		);
 	}
 }

--- a/includes/Type/InterfaceType/PostTypeBlockInterface.php
+++ b/includes/Type/InterfaceType/PostTypeBlockInterface.php
@@ -20,16 +20,16 @@ final class PostTypeBlockInterface {
 	 * @param string   $post_type The post type.
 	 * @param string[] $block_names The list of allowed block names.
 	 */
-	public static function register_type( string $post_type, array $block_names = array() ): void {
+	public static function register_type( string $post_type, array $block_names = [] ): void {
 		register_graphql_interface_type(
 			ucfirst( $post_type ) . 'EditorBlock',
-			array(
-				'interfaces'  => array( 'EditorBlock' ),
-				'fields'      => array(
-					'name' => array(
+			[
+				'interfaces'  => [ 'EditorBlock' ],
+				'fields'      => [
+					'name' => [
 						'type' => 'String',
-					),
-				),
+					],
+				],
 				'resolveType' => function ( $block ) {
 					if ( empty( $block['blockName'] ) ) {
 						$block['blockName'] = 'core/freeform';
@@ -39,29 +39,29 @@ final class PostTypeBlockInterface {
 
 					return WPGraphQLHelpers::format_type_name( $type_name );
 				},
-			)
+			]
 		);
 
 		register_graphql_interface_type(
 			'NodeWith' . ucfirst( $post_type ) . 'EditorBlocks',
-			array(
+			[
 				'description'     => sprintf(
 					// translators: %s is the post type.
 					__( 'Node that has %s content blocks associated with it', 'wp-graphql-content-blocks' ),
 					$post_type
 				),
 				'eagerlyLoadType' => true,
-				'interfaces'      => array( 'NodeWithEditorBlocks' ),
-				'fields'          => array(
-					'editorBlocks' => array(
-						'type'        => array(
+				'interfaces'      => [ 'NodeWithEditorBlocks' ],
+				'fields'          => [
+					'editorBlocks' => [
+						'type'        => [
 							'list_of' => ucfirst( $post_type ) . 'EditorBlock',
-						),
-						'args'        => array(
-							'flat' => array(
+						],
+						'args'        => [
+							'flat' => [
 								'type' => 'Boolean',
-							),
-						),
+							],
+						],
 						'description' => sprintf(
 							// translators: %s is the post type.
 							__( 'List of %s editor blocks', 'wp-graphql-content-blocks' ),
@@ -70,9 +70,9 @@ final class PostTypeBlockInterface {
 						'resolve'     => function ( $node, $args ) use ( $block_names ) {
 							return ContentBlocksResolver::resolve_content_blocks( $node, $args, $block_names );
 						},
-					),
-				),
-			)
+					],
+				],
+			]
 		);
 	}
 

--- a/includes/Type/InterfaceType/PostTypeBlockInterface.php
+++ b/includes/Type/InterfaceType/PostTypeBlockInterface.php
@@ -30,7 +30,7 @@ final class PostTypeBlockInterface {
 						'type' => 'String',
 					],
 				],
-				'resolveType' => function ( $block ) {
+				'resolveType' => static function ( $block ) {
 					if ( empty( $block['blockName'] ) ) {
 						$block['blockName'] = 'core/freeform';
 					}
@@ -67,7 +67,7 @@ final class PostTypeBlockInterface {
 							__( 'List of %s editor blocks', 'wp-graphql-content-blocks' ),
 							$post_type
 						),
-						'resolve'     => function ( $node, $args ) use ( $block_names ) {
+						'resolve'     => static function ( $node, $args ) use ( $block_names ) {
 							return ContentBlocksResolver::resolve_content_blocks( $node, $args, $block_names );
 						},
 					],

--- a/includes/Type/InterfaceType/PostTypeBlockInterface.php
+++ b/includes/Type/InterfaceType/PostTypeBlockInterface.php
@@ -75,5 +75,4 @@ final class PostTypeBlockInterface {
 			]
 		);
 	}
-
 }

--- a/includes/Type/Scalar/Scalar.php
+++ b/includes/Type/Scalar/Scalar.php
@@ -17,11 +17,11 @@ final class Scalar {
 	public function init(): void {
 		register_graphql_scalar(
 			'BlockAttributesObject',
-			array(
+			[
 				'serialize' => function ( $value ) {
 					return wp_json_encode( $value );
 				},
-			)
+			]
 		);
 	}
 

--- a/includes/Type/Scalar/Scalar.php
+++ b/includes/Type/Scalar/Scalar.php
@@ -18,7 +18,7 @@ final class Scalar {
 		register_graphql_scalar(
 			'BlockAttributesObject',
 			[
-				'serialize' => function ( $value ) {
+				'serialize' => static function ( $value ) {
 					return wp_json_encode( $value );
 				},
 			]

--- a/includes/WPGraphQLContentBlocks.php
+++ b/includes/WPGraphQLContentBlocks.php
@@ -23,7 +23,7 @@ final class WPGraphQLContentBlocks {
 	/**
 	 * The instance of the WPGraphQLContentBlocks object
 	 *
-	 * @return object|WPGraphQLContentBlocks
+	 * @return object|\WPGraphQLContentBlocks
 	 * @since  0.0.1
 	 */
 	public static function instance() {
@@ -160,7 +160,7 @@ final class WPGraphQLContentBlocks {
 	 * @since 0.0.1
 	 */
 	public function actions(): void {
-		add_action( 'graphql_register_types', array( $this, 'init_block_editor_registry' ) );
+		add_action( 'graphql_register_types', [ $this, 'init_block_editor_registry' ] );
 	}
 
 	/**

--- a/includes/WPGraphQLContentBlocks.php
+++ b/includes/WPGraphQLContentBlocks.php
@@ -12,7 +12,6 @@
  * Main WPGraphQLContentBlocks Class.
  */
 final class WPGraphQLContentBlocks {
-
 	/**
 	 * The one true WPGraphQLContentBlocks
 	 *
@@ -70,7 +69,6 @@ final class WPGraphQLContentBlocks {
 	 * Setup plugin constants.
 	 *
 	 * @since  0.0.1
-	 * @return void
 	 */
 	private function setup_constants(): void {
 
@@ -94,7 +92,6 @@ final class WPGraphQLContentBlocks {
 	 * Uses composer's autoload
 	 *
 	 * @since  0.0.1
-	 * @return bool
 	 */
 	private function includes(): bool {
 		/**

--- a/includes/WPGraphQLContentBlocks.php
+++ b/includes/WPGraphQLContentBlocks.php
@@ -18,7 +18,7 @@ final class WPGraphQLContentBlocks {
 	 *
 	 * @var ?self
 	 */
-	private static ?WPGraphQLContentBlocks $instance;
+	private static ?self $instance;
 
 	/**
 	 * The instance of the WPGraphQLContentBlocks object
@@ -27,8 +27,8 @@ final class WPGraphQLContentBlocks {
 	 * @since  0.0.1
 	 */
 	public static function instance() {
-		if ( ! isset( self::$instance ) || ! ( self::$instance instanceof WPGraphQLContentBlocks ) ) {
-			self::$instance = new WPGraphQLContentBlocks();
+		if ( ! isset( self::$instance ) || ! ( self::$instance instanceof self ) ) {
+			self::$instance = new self();
 			self::$instance->setup_constants();
 			if ( self::$instance->includes() ) {
 				self::$instance->actions();
@@ -110,7 +110,7 @@ final class WPGraphQLContentBlocks {
 			} else {
 				add_action(
 					'admin_notices',
-					function () {
+					static function () {
 						if ( ! current_user_can( 'manage_options' ) ) {
 							return;
 						}
@@ -133,7 +133,7 @@ final class WPGraphQLContentBlocks {
 			if ( ! class_exists( 'WPGraphQL' ) ) {
 				add_action(
 					'admin_notices',
-					function () {
+					static function () {
 						if ( ! current_user_can( 'manage_options' ) ) {
 							return;
 						}

--- a/includes/utilities/DomHelpers.php
+++ b/includes/utilities/DomHelpers.php
@@ -32,8 +32,7 @@ final class DOMHelpers {
 		}
 		$node          = $doc->find( $selector );
 		$default_value = isset( $default_value ) ? $default_value : null;
-		$value         = ( ! empty( $node ) && isset( $node[0] ) ) ? $node[0]->getAttribute( $attribute ) : $default_value;
-		return $value;
+		return ( ! empty( $node ) && isset( $node[0] ) ) ? $node[0]->getAttribute( $attribute ) : $default_value;
 	}
 
 	/**

--- a/includes/utilities/WPHelpers.php
+++ b/includes/utilities/WPHelpers.php
@@ -21,7 +21,7 @@ final class WPHelpers {
 	 * @return \WP_Post_Type[]
 	 */
 	public static function get_supported_post_types(): array {
-		$supported_post_types = array();
+		$supported_post_types = [];
 		/**
 		 * Get Post Types that are set to Show in GraphQL and Show in REST.
 		 * If it doesn't show in REST, it's not block-editor.
@@ -62,7 +62,7 @@ final class WPHelpers {
 	 * @param string $post_type The Post Type to use.
 	 * @param int    $id The Post ID to use.
 	 *
-	 * @return WP_Block_Editor_Context The Block Editor Context
+	 * @return \WP_Block_Editor_Context The Block Editor Context
 	 */
 	public static function get_block_editor_context( string $post_type, $id = -99 ): WP_Block_Editor_Context {
 		$post_id              = $id;
@@ -81,6 +81,6 @@ final class WPHelpers {
 		$post->post_type = $post_type;
 		$post->filter    = 'raw';
 
-		return new WP_Block_Editor_Context( array( 'post' => new WP_Post( $post ) ) );
+		return new WP_Block_Editor_Context( [ 'post' => new WP_Post( $post ) ] );
 	}
 }

--- a/includes/utilities/WPHelpers.php
+++ b/includes/utilities/WPHelpers.php
@@ -7,9 +7,9 @@
 
 namespace WPGraphQL\ContentBlocks\Utilities;
 
-use stdClass;
-use WP_Post;
 use WP_Block_Editor_Context;
+use WP_Post;
+use stdClass;
 
 /**
  * Class WPHelpers


### PR DESCRIPTION
This PR illustrates the effects of bringing this projects coding standards in-line with those used by WPGraphQL, as proposed in #91 . It is _not_ meant to be merged.

The `wp-graphql-cs` library is just included for ease of example, and is not a requisite for adopting the rules it contains.

`WPGraphQL-Minimum` applies the rules currently used by WPGraphQL core. 
The `WPGraphQL-Strict` ruleset is a proposal for core and includes a significant number of functional sniffs. See: https://github.com/wp-graphql/wp-graphql/pull/2830
The `WPGraphQL` ruleset includes docs and formatting sniffs.

Note: The wpengine-cs library was removed, as it hasnt been updated in 3 years, and the dependencies were conflicting. The only explicit rules from `WPEngine-Strict` that arent already included in the ecosystem ruleset are included in `.phpcs.xml.dist`

Best way to review would be to traverse the diffs of the individual commits.