### PR TITLE
CI/CD: Run tests against php8.2+mysql8.0

### DIFF
--- a/.docker/Dockerfile
+++ b/.docker/Dockerfile
@@ -1,12 +1,12 @@
-ARG WP_VERSION=latest
-
-FROM wordpress:${WP_VERSION}
-
-# Needed to specify the build args again after the FROM command.
 ARG WP_VERSION
+ARG PHP_VERSION
+
+FROM wordpress:${WP_VERSION}-php${PHP_VERSION}
 
 # Save the build args for use by the runtime environment
 ENV WP_VERSION=${WP_VERSION}
+ENV PHP_VERSION=${PHP_VERSION}
+
 
 # Needed for Codeception WPDB test integration.
 RUN docker-php-ext-install pdo pdo_mysql

--- a/.github/workflows/schema-linter.yml
+++ b/.github/workflows/schema-linter.yml
@@ -65,7 +65,7 @@ jobs:
           echo "Previous tagged schema ${{ steps.get-latest-tag.outputs.tag }}"
 
       - name: Get Previous Released Schema
-        run: curl 'https://github.com/wp-graphql-content-blocks/releases/download/${{ steps.get-latest-tag.outputs.tag }}/schema.graphql' -L  --output /tmp/${{ steps.get-latest-tag.outputs.tag }}.graphql
+        run: curl 'https://github.com/wpengine/wp-graphql-content-blocks/releases/download/${{ steps.get-latest-tag.outputs.tag }}/schema.graphql' -L  --output /tmp/${{ steps.get-latest-tag.outputs.tag }}.graphql
 
       # https://github.com/marketplace/actions/graphql-inspector
       - name: Install Schema Inspector

--- a/.github/workflows/test-plugin.yml
+++ b/.github/workflows/test-plugin.yml
@@ -27,11 +27,7 @@ jobs:
           docker-compose build \
             --build-arg WP_VERSION=${{ matrix.wordpress }} \
             --build-arg PHP_VERSION=${{ matrix.php }}
-          docker-compose run \
-            -e PHP_VERSION=${{ matrix.php }} \
-            -e WP_VERSION=${{ matrix.wordpress }} \
-            -e COVERAGE=1
-            wordpress
+          docker-compose up -d
 
       - name: Wait for db
         run: |

--- a/.github/workflows/test-plugin.yml
+++ b/.github/workflows/test-plugin.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       matrix:
         php: [ '8.2', '7.4' ]
-        wordpress: [ '6.1', '5.9' ]
+        wordpress: [ '6.2', '5.9' ]
         exclude:
         - php: 8.2
           wordpress: 5.9

--- a/.github/workflows/test-plugin.yml
+++ b/.github/workflows/test-plugin.yml
@@ -11,10 +11,12 @@ jobs:
     strategy:
       matrix:
         php: [ '8.2', '7.4' ]
-        wordpress: [ '6.2', '5.9' ]
+        wordpress: [ '6.1', '6.2', '5.9' ]
         exclude:
         - php: 8.2
           wordpress: 5.9
+        - php: 7.4
+          wordpress: 6.2
       fail-fast: false
     name: WordPress ${{ matrix.wordpress }}, PHP ${{ matrix.php }}
     steps:

--- a/.github/workflows/test-plugin.yml
+++ b/.github/workflows/test-plugin.yml
@@ -8,13 +8,30 @@ on:
 jobs:
   test_plugin:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        php: [ '8.2', '7.4' ]
+        wordpress: [ '6.1', '5.9' ]
+      fail-fast: false
+    name: WordPress ${{ matrix.wordpress }}, PHP ${{ matrix.php }}
     steps:
       - name: Checkout
         uses: actions/checkout@v3
 
       - name: Create Docker Containers
+        env:
+          PHP_VERSION: ${{ matrix.php }}
+          WP_VERSION: ${{ matrix.wordpress }}
         working-directory: ./
-        run: docker-compose up -d
+        run: |
+          docker-compose build \
+            --build-arg WP_VERSION=${{ matrix.wordpress }} \
+            --build-arg PHP_VERSION=${{ matrix.php }}
+          docker-compose run \
+            -e PHP_VERSION=${{ matrix.php }} \
+            -e WP_VERSION=${{ matrix.wordpress }} \
+            -e COVERAGE=1
+            wordpress
 
       - name: Wait for db
         run: |

--- a/.github/workflows/test-plugin.yml
+++ b/.github/workflows/test-plugin.yml
@@ -12,6 +12,9 @@ jobs:
       matrix:
         php: [ '8.2', '7.4' ]
         wordpress: [ '6.1', '5.9' ]
+        exclude:
+        - php: 8.2
+          wordpress: 5.9
       fail-fast: false
     name: WordPress ${{ matrix.wordpress }}, PHP ${{ matrix.php }}
     steps:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,13 +4,15 @@ services:
   wordpress:
     build:
       context: ./.docker
-    image: wp-graphql-content-blocks:latest-wp-${WP_VERSION-latest}
+    image: wp-graphql-content-blocks:latest-wp-${WP_VERSION-latest}-php${PHP_VERSION}
     restart: always
     ports:
       - 8080:80
     links:
       - db
     environment:
+      PHP_VERSION: ${PHP_VERSION:-8.2}
+      WP_VERSION: ${WP_VERSION:-6.1}
       WORDPRESS_DB_HOST: db
       WORDPRESS_DB_NAME: wordpress
       WORDPRESS_DB_USER: root
@@ -24,7 +26,7 @@ services:
       - ./:/var/www/html/wp-content/plugins/wp-graphql-content-blocks
 
   db:
-    image: mysql:5.7
+    image: mysql:8
     restart: always
     ports:
       - 33066:3306

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,7 +12,7 @@ services:
       - db
     environment:
       PHP_VERSION: ${PHP_VERSION:-8.2}
-      WP_VERSION: ${WP_VERSION:-6.1}
+      WP_VERSION: ${WP_VERSION:-6.2}
       WORDPRESS_DB_HOST: db
       WORDPRESS_DB_NAME: wordpress
       WORDPRESS_DB_USER: root


### PR DESCRIPTION
Description
---

Add GH actions matrix to run unit tests  against the following combinations of php, WP and MySQL

php: [ '8.2', '7.4' ]
WordPress: [ '6.2', '6.1', '5.9' ]
mySql: 8.0

Excluded: Docker images for  WordPress v5.9 and php v8.2 are not available.