### PR TITLE
Bug Fix: Parsing boolean block attributes like in CoreVideo always return false.

### DIFF
--- a/.changeset/spicy-tables-cross.md
+++ b/.changeset/spicy-tables-cross.md
@@ -1,0 +1,5 @@
+---
+"@wpengine/wp-graphql-content-blocks": patch
+---
+
+Bug Fix. Boolean attributes always resolve as false. For example when using the CoreVideo block.

--- a/.changeset/spicy-tables-cross.md
+++ b/.changeset/spicy-tables-cross.md
@@ -2,4 +2,4 @@
 "@wpengine/wp-graphql-content-blocks": patch
 ---
 
-Bug Fix. Boolean attributes always resolve as false. For example when using the CoreVideo block.
+Bug Fix. Boolean block attributes no longer always resolve as false.

--- a/includes/Blocks/Block.php
+++ b/includes/Blocks/Block.php
@@ -286,10 +286,15 @@ class Block {
 
 					break;
 			}//end switch
-
-			// if type is set to integer, get the integer value of the attribute.
-			if ( 'integer' === $attribute_config['type'] ) {
-				$value = intval( $value );
+			// Post processing of return value based on configured type
+			switch ( $attribute_config['type'] ) {
+				case 'integer':
+					$value = intval( $value );
+					break;
+				case 'boolean':
+					// Only false when value is not null or actually false
+					$value = ! ( false === $value || is_null( $value ) );
+					break;
 			}
 
 			return $value;

--- a/includes/Blocks/Block.php
+++ b/includes/Blocks/Block.php
@@ -292,8 +292,12 @@ class Block {
 					$value = intval( $value );
 					break;
 				case 'boolean':
-					// Only false when value is not null or actually false
-					$value = ! ( false === $value || is_null( $value ) );
+					// If the value is empty or false return
+					if ( is_null( $value ) || false === $value ) {
+						break;
+					}
+					// Otherwise it's truthy
+					$value = true;
 					break;
 			}
 

--- a/tests/unit/blocks/CoreVideoTest.php
+++ b/tests/unit/blocks/CoreVideoTest.php
@@ -1,0 +1,95 @@
+<?php
+
+namespace WPGraphQL\ContentBlocks\Unit;
+
+final class CoreVideoTest extends PluginTestCase {
+    public $instance;
+	public $post_id;
+    
+    public function setUp(): void {
+		parent::setUp();
+		global $wpdb;
+
+		$this->post_id = wp_insert_post(
+			array(
+				'post_title'   => 'Post Title',
+				'post_content' => preg_replace(
+					'/\s+/',
+					' ',
+					trim(
+						'
+                        <!-- wp:video {"id":1636} -->
+                        <figure class="wp-block-video"><video autoplay controls loop poster="http://mysite.local/wp-content/uploads/2023/05/pexels-egor-komarov-14420089-scaled.jpg" preload="auto" src="http://mysite.local/wp-content/uploads/2023/07/pexels_videos_1860684-1440p.mp4" playsinline></video></figure>
+                        <!-- /wp:video -->
+                        '
+					)
+				),
+				'post_status'  => 'publish',
+			)
+		);
+	}
+
+    public function tearDown(): void {
+		// your tear down methods here
+		parent::tearDown();
+		wp_delete_post( $this->post_id, true );
+	}
+
+    public function test_retrieve_core_video_attributes() {
+		$query  = '  
+		  fragment CoreVideoBlockFragment on CoreVideo {
+			attributes {
+              align
+              anchor
+              autoplay
+              tracks
+              muted
+              caption
+              preload
+              src
+              playsInline
+              controls
+              loop
+              poster
+              id
+            }
+		  }
+		  
+		  query GetPosts {
+			posts(first: 1) {
+			  nodes {
+				databaseId
+				editorBlocks {
+				  name
+				  ...CoreVideoBlockFragment
+				}
+			  }
+			}
+		  }
+		';
+		$actual = graphql( array( 'query' => $query ) );
+		$node   = $actual['data']['posts']['nodes'][0];
+		
+		// Verify that the ID of the first post matches the one we just created.
+		$this->assertEquals( $this->post_id, $node['databaseId'] );
+		// There should be only one block using that query when not using flat: true
+		$this->assertEquals( count( $node['editorBlocks'] ), 1 );
+		$this->assertEquals( $node['editorBlocks'][0]['name'], 'core/video' );
+
+		$this->assertEquals( $node['editorBlocks'][0]['attributes'], [
+            'align' => null,
+            'anchor' => null,
+            'autoplay' => true,
+            'tracks' => '[]',
+            'muted' => false,
+            'caption' => '',
+            'preload' => 'auto',
+            'src' => 'http://mysite.local/wp-content/uploads/2023/07/pexels_videos_1860684-1440p.mp4',
+            'playsInline' => true,
+            'controls' => true,
+            'loop' => true,
+            'poster' => 'http://mysite.local/wp-content/uploads/2023/05/pexels-egor-komarov-14420089-scaled.jpg',
+            'id' => 1636.0,
+		]); 
+	}
+}

--- a/tests/unit/blocks/CoreVideoTest.php
+++ b/tests/unit/blocks/CoreVideoTest.php
@@ -19,7 +19,7 @@ final class CoreVideoTest extends PluginTestCase {
 					trim(
 						'
                         <!-- wp:video {"id":1636} -->
-                        <figure class="wp-block-video"><video autoplay controls loop poster="http://mysite.local/wp-content/uploads/2023/05/pexels-egor-komarov-14420089-scaled.jpg" preload="auto" src="http://mysite.local/wp-content/uploads/2023/07/pexels_videos_1860684-1440p.mp4" playsinline></video></figure>
+                        <figure class="wp-block-video"><video autoplay loop poster="http://mysite.local/wp-content/uploads/2023/05/pexels-egor-komarov-14420089-scaled.jpg" preload="auto" src="http://mysite.local/wp-content/uploads/2023/07/pexels_videos_1860684-1440p.mp4" playsinline></video></figure>
                         <!-- /wp:video -->
                         '
 					)
@@ -86,7 +86,7 @@ final class CoreVideoTest extends PluginTestCase {
             'preload' => 'auto',
             'src' => 'http://mysite.local/wp-content/uploads/2023/07/pexels_videos_1860684-1440p.mp4',
             'playsInline' => true,
-            'controls' => true,
+            'controls' => null,
             'loop' => true,
             'poster' => 'http://mysite.local/wp-content/uploads/2023/05/pexels-egor-komarov-14420089-scaled.jpg',
             'id' => 1636.0,


### PR DESCRIPTION
# Description

Bug fix. Parsing boolean block attributes like in CoreVideo always return false. 

Fixes: https://github.com/wpengine/wp-graphql-content-blocks/issues/135

# Testing

1. Add a CoreVideo block in a Post and enable some of its checkbox settings for autoplay on the side.
2. Try to query the block attributes.
3. The boolean attributes should return the correct checked/unchecked value.