### PR TITLE
Refactor: (Performance) `register_graphql_interfaces` no longer used in `register_block_types`

### DIFF
--- a/.changeset/thin-insects-sparkle.md
+++ b/.changeset/thin-insects-sparkle.md
@@ -3,9 +3,6 @@
 ---
 
 Refactored `register_block_types` to remove usages of `register_graphql_interfaces_to_types` to improve performance.
-<<<<<<< HEAD
-**MINOR BREAKING** Removed `Anchor::register_to_block` public static method.
-=======
 
 Deprecated `Anchor::register_to_block` public static method.
->>>>>>> 989f243 (Chore: Deprecate `register_to_block` instead.)
+

--- a/.changeset/thin-insects-sparkle.md
+++ b/.changeset/thin-insects-sparkle.md
@@ -3,3 +3,4 @@
 ---
 
 Refactored `register_block_types` to remove usages of `register_graphql_interfaces_to_types` to improve performance.
+**MINOR BREAKING** Removed `Anchor::register_to_block` static method.

--- a/.changeset/thin-insects-sparkle.md
+++ b/.changeset/thin-insects-sparkle.md
@@ -1,0 +1,5 @@
+---
+"@wpengine/wp-graphql-content-blocks": patch
+---
+
+Refactored `register_block_types` to remove usages of `register_graphql_interfaces_to_types` to improve performance.

--- a/.changeset/thin-insects-sparkle.md
+++ b/.changeset/thin-insects-sparkle.md
@@ -3,4 +3,4 @@
 ---
 
 Refactored `register_block_types` to remove usages of `register_graphql_interfaces_to_types` to improve performance.
-**MINOR BREAKING** Removed `Anchor::register_to_block` static method.
+**MINOR BREAKING** Removed `Anchor::register_to_block` public static method.

--- a/.changeset/thin-insects-sparkle.md
+++ b/.changeset/thin-insects-sparkle.md
@@ -3,4 +3,9 @@
 ---
 
 Refactored `register_block_types` to remove usages of `register_graphql_interfaces_to_types` to improve performance.
+<<<<<<< HEAD
 **MINOR BREAKING** Removed `Anchor::register_to_block` public static method.
+=======
+
+Deprecated `Anchor::register_to_block` public static method.
+>>>>>>> 989f243 (Chore: Deprecate `register_to_block` instead.)

--- a/includes/Blocks/Block.php
+++ b/includes/Blocks/Block.php
@@ -76,7 +76,6 @@ class Block {
 	private function register_block_type() {
 		$this->register_block_attributes_as_fields();
 		$this->register_type();
-		$this->register_block_support_fields();
 	}
 
 	/**
@@ -100,6 +99,7 @@ class Block {
 						__( 'Attributes of the %s Block Type', 'wp-graphql-content-blocks' ),
 						$this->type_name
 					),
+					'interfaces'  => $this->get_block_attributes_interfaces(),
 					'fields'      => $block_attribute_fields,
 				)
 			);
@@ -120,13 +120,6 @@ class Block {
 				)
 			);
 		}//end if
-	}
-
-	/**
-	 * Registers fields for the block supports.
-	 */
-	private function register_block_support_fields(): void {
-		Anchor::register_to_block( $this->block );
 	}
 
 	/**
@@ -198,6 +191,15 @@ class Block {
 	 */
 	private function get_block_interfaces(): array {
 		return $this->block_registry->get_block_interfaces( $this->block->name );
+	}
+
+	/**
+	 * Gets the GraphQL interfaces that should be implemented by the block attributes object.
+	 *
+	 * @return string[]
+	 */
+	private function get_block_attributes_interfaces(): array {
+		return $this->block_registry->get_block_attributes_interfaces( $this->block->name );
 	}
 
 	/**

--- a/includes/Field/BlockSupports/Anchor.php
+++ b/includes/Field/BlockSupports/Anchor.php
@@ -9,6 +9,7 @@ namespace WPGraphQL\ContentBlocks\Field\BlockSupports;
 
 use WP_Block_Type;
 use WPGraphQL\ContentBlocks\Utilities\DOMHelpers;
+use WPGraphQL\ContentBlocks\Utilities\WPGraphQLHelpers;
 
 /**
  * Class - Anchor
@@ -64,5 +65,20 @@ class Anchor {
 	 */
 	public static function get_block_attributes_interfaces( $existing, \WP_Block_Type $block_spec ): array {
 		return self::get_block_interfaces( $existing, $block_spec );
+	}
+
+	/**
+	 * Registers an Anchor field on a block if it supports it.
+	 *
+	 * @param \WP_Block_Type $block_spec The block type to register the anchor field against.
+	 * @return void
+	 *
+	 * @deprecated 1.1.4 No longer used by internal code and not recommended.
+	 */
+	public static function register_to_block( \WP_Block_Type $block_spec ): void {
+		if ( isset( $block_spec->supports['anchor'] ) && true === $block_spec->supports['anchor'] ) {
+			register_graphql_interfaces_to_types( 'BlockWithSupportsAnchor', array( WPGraphQLHelpers::format_type_name( $block_spec->name ) . 'Attributes' ) );
+			register_graphql_interfaces_to_types( 'BlockWithSupportsAnchor', array( WPGraphQLHelpers::format_type_name( $block_spec->name ) ) );
+		}
 	}
 }

--- a/includes/Field/BlockSupports/Anchor.php
+++ b/includes/Field/BlockSupports/Anchor.php
@@ -9,7 +9,6 @@ namespace WPGraphQL\ContentBlocks\Field\BlockSupports;
 
 use WP_Block_Type;
 use WPGraphQL\ContentBlocks\Utilities\DOMHelpers;
-use WPGraphQL\ContentBlocks\Utilities\WPGraphQLHelpers;
 
 /**
  * Class - Anchor
@@ -41,15 +40,29 @@ class Anchor {
 	}
 
 	/**
-	 * Registers an Anchor field on a block if it supports it.
+	 * Checks if the block spec supports the anchor field and returns the relevant interface
 	 *
+	 * @param array          $existing An existing list of a block interfaces.
 	 * @param \WP_Block_Type $block_spec The block type to register the anchor field against.
-	 * @return void
+	 *
+	 * @return string[]
 	 */
-	public static function register_to_block( \WP_Block_Type $block_spec ): void {
-		if ( isset( $block_spec->supports['anchor'] ) && true === $block_spec->supports['anchor'] ) {
-			register_graphql_interfaces_to_types( 'BlockWithSupportsAnchor', array( WPGraphQLHelpers::format_type_name( $block_spec->name ) . 'Attributes' ) );
-			register_graphql_interfaces_to_types( 'BlockWithSupportsAnchor', array( WPGraphQLHelpers::format_type_name( $block_spec->name ) ) );
+	public static function get_block_interfaces( $existing, \WP_Block_Type $block_spec ): array {
+		if ( isset( $block_spec ) && isset( $block_spec->supports['anchor'] ) && true === $block_spec->supports['anchor'] ) {
+			$existing[] = 'BlockWithSupportsAnchor';
 		}
+		return $existing;
+	}
+
+	/**
+	 * Checks if the block spec supports the anchor field and returns the relevant interface
+	 *
+	 * @param array          $existing An existing list of a block attribute interfaces.
+	 * @param \WP_Block_Type $block_spec The block type to register the anchor field against.
+	 *
+	 * @return string[]
+	 */
+	public static function get_block_attributes_interfaces( $existing, \WP_Block_Type $block_spec ): array {
+		return self::get_block_interfaces( $existing, $block_spec );
 	}
 }

--- a/includes/Field/BlockSupports/Anchor.php
+++ b/includes/Field/BlockSupports/Anchor.php
@@ -76,6 +76,7 @@ class Anchor {
 	 * @deprecated 1.1.4 No longer used by internal code and not recommended.
 	 */
 	public static function register_to_block( \WP_Block_Type $block_spec ): void {
+		_deprecated_function( __METHOD__, '1.1.4' );
 		if ( isset( $block_spec->supports['anchor'] ) && true === $block_spec->supports['anchor'] ) {
 			register_graphql_interfaces_to_types( 'BlockWithSupportsAnchor', array( WPGraphQLHelpers::format_type_name( $block_spec->name ) . 'Attributes' ) );
 			register_graphql_interfaces_to_types( 'BlockWithSupportsAnchor', array( WPGraphQLHelpers::format_type_name( $block_spec->name ) ) );

--- a/includes/Registry/Registry.php
+++ b/includes/Registry/Registry.php
@@ -154,7 +154,6 @@ final class Registry {
 	 * @return string[]
 	 */
 	public function get_block_additional_interfaces( string $block_name ): array {
-
 		$block_spec       = $this->block_type_registry->get_registered( $block_name );
 		$block_interfaces = array();
 		// NOTE: Using add_filter here creates a performance penalty sadly

--- a/includes/Registry/Registry.php
+++ b/includes/Registry/Registry.php
@@ -156,7 +156,7 @@ final class Registry {
 	public function get_block_additional_interfaces( string $block_name ): array {
 		$block_spec       = $this->block_type_registry->get_registered( $block_name );
 		$block_interfaces = array();
-		// NOTE: Using add_filter here creates a performance penalty sadly
+		// NOTE: Using add_filter here creates a performance penalty.
 		$block_interfaces = Anchor::get_block_interfaces( $block_interfaces, $block_spec );
 		return $block_interfaces;
 	}
@@ -171,7 +171,7 @@ final class Registry {
 	public function get_block_attributes_interfaces( string $block_name ): array {
 		$block_spec       = $this->block_type_registry->get_registered( $block_name );
 		$block_interfaces = array();
-		// NOTE: Using add_filter here creates a performance penalty sadly
+		// NOTE: Using add_filter here creates a performance penalty.
 		$block_interfaces = Anchor::get_block_attributes_interfaces( $block_interfaces, $block_spec );
 		return $block_interfaces;
 	}

--- a/includes/Registry/Registry.php
+++ b/includes/Registry/Registry.php
@@ -70,8 +70,8 @@ final class Registry {
 	public function init(): void {
 		$this->register_interface_types();
 		$this->register_scalar_types();
-		$this->register_block_types();
 		$this->register_support_block_types();
+		$this->register_block_types();
 	}
 
 	/**
@@ -140,8 +140,41 @@ final class Registry {
 		// Get the interfaces a block should implement based on the context a block is available to be accessed from.
 		$context_interfaces = $this->get_block_context_interfaces( $block_name );
 
-		// @todo: if blocks need to implement other interfaces (i.e. "BlockSupports" interfaces, that could be handled here as well)
-		return array_merge( array( 'EditorBlock' ), $context_interfaces );
+		// Get additional interfaces a block should implement.
+		$additional_interfaces = $this->get_block_additional_interfaces( $block_name );
+
+		return array_merge( array( 'EditorBlock' ), $context_interfaces, $additional_interfaces );
+	}
+
+	/**
+	 * Given the name of a Block, return interfaces the Block object should implement.
+	 *
+	 * @param string $block_name The name of the block to get the interfaces for.
+	 *
+	 * @return string[]
+	 */
+	public function get_block_additional_interfaces( string $block_name ): array {
+
+		$block_spec       = $this->block_type_registry->get_registered( $block_name );
+		$block_interfaces = array();
+		// NOTE: Using add_filter here creates a performance penalty sadly
+		$block_interfaces = Anchor::get_block_interfaces( $block_interfaces, $block_spec );
+		return $block_interfaces;
+	}
+
+	/**
+	 * Given the name of a Block, return interfaces the Block attributes object should implement.
+	 *
+	 * @param string $block_name The name of the block to get the interfaces for.
+	 *
+	 * @return string[]
+	 */
+	public function get_block_attributes_interfaces( string $block_name ): array {
+		$block_spec       = $this->block_type_registry->get_registered( $block_name );
+		$block_interfaces = array();
+		// NOTE: Using add_filter here creates a performance penalty sadly
+		$block_interfaces = Anchor::get_block_attributes_interfaces( $block_interfaces, $block_spec );
+		return $block_interfaces;
 	}
 
 	/**


### PR DESCRIPTION
# Description

* Removed usage of `register_graphql_interfaces` to_types in `register_block_types`
* Related [Comment](https://github.com/wpengine/wp-graphql-content-blocks/issues/134#issuecomment-1652113161)


# Manual Load testing results

* Populated WP site with 100 Posts and 100 Pages.

* Using [autocannon.js](https://github.com/mcollina/autocannon
) script:

```js
const autocannon = require("autocannon");

const instance = autocannon(
  {
    url: "http://mysite.local",
    connections: 12,
    pipelining: 1,
    duration: 30,
    headers: {
      accept: "application/json",
      "accept-language": "en-GB,en;q=0.9,de;q=0.8,el;q=0.7,en-US;q=0.6",
      "cache-control": "no-cache",
      "content-type": "application/json",
      pragma: "no-cache",
      Referer: "http://mysite.local/wp-admin/admin.php?page=graphiql-ide",
      "Referrer-Policy": "strict-origin-when-cross-origin",
    },
    requests: [
        {
          method: 'POST',
          path: '/index.php?graphql',
          body: "{\"query\":\"{\\n  posts {\\n    nodes {\\n      editorBlocks {\\n        renderedHtml\\n        name\\n        ...on CoreCover {\\n          anchor\\n        }\\n        ...on CoreParagraph {\\n          anchor\\n        }\\n      }\\n    }\\n  }\\n}\",\"variables\":{\"databaseId\":\"/posts/example-codeblock\"}}",
        },
    ]
  },
  (err, result) => handleResults(result)
);

instance.on("response", handleResponse);

function handleResponse(client, statusCode, resBytes, responseTime) {
  console.log(
    `Got response with code ${statusCode} in ${responseTime} milliseconds`
  );
  console.log(`response: ${resBytes.toString()}`);
}

function handleResults(result) {
  console.log(result);
}

```

## Load Testing Results (Latency numbers in ms)

**PLUGIN DISABLED**
```js
{
  title: "Load testing with Plugin disabled",
  url: 'http://mysite.local',
  socketPath: undefined,
  connections: 12,
  sampleInt: 1000,
  pipelining: 1,
  workers: undefined,
  duration: 30.04,
  samples: 30,
  start: 2023-08-15T12:48:38.221Z,
  finish: 2023-08-15T12:49:08.258Z,
  errors: 0,
  timeouts: 0,
  mismatches: 0,
  non2xx: 0,
  resets: 0,
  '1xx': 0,
  '2xx': 972,
  '3xx': 0,
  '4xx': 0,
  '5xx': 0,
  statusCodeStats: { '200': { count: 972 } },
  latency: {
    average: 367.59,
    mean: 367.59,
    stddev: 24.09,
    min: 68,
    max: 438,
    p0_001: 68,
    p0_01: 68,
    p0_1: 68,
    p1: 304,
    p2_5: 354,
    p10: 358,
    p25: 361,
    p50: 366,
    p75: 374,
    p90: 381,
    p97_5: 408,
    p99: 424,
    p99_9: 438,
    p99_99: 438,
    p99_999: 438,
    totalCount: 972
  },
  requests: {
    average: 32.4,
    mean: 32.4,
    stddev: 1.09,
    min: 30,
    max: 34,
    total: 972,
    p0_001: 30,
    p0_01: 30,
    p0_1: 30,
    p1: 30,
    p2_5: 30,
    p10: 32,
    p25: 32,
    p50: 32,
    p75: 34,
    p90: 34,
    p97_5: 34,
    p99: 34,
    p99_9: 34,
    p99_99: 34,
    p99_999: 34,
    sent: 984
  },
  throughput: {
    average: 382506.67,
    mean: 382506.67,
    stddev: 12856.77,
    min: 354210,
    max: 401438,
    total: 11476404,
    p0_001: 354303,
    p0_01: 354303,
    p0_1: 354303,
    p1: 354303,
    p2_5: 354303,
    p10: 377855,
    p25: 377855,
    p50: 377855,
    p75: 401663,
    p90: 401663,
    p97_5: 401663,
    p99: 401663,
    p99_9: 401663,
    p99_99: 401663,
    p99_999: 401663
  }
}
```

**PLUGIN ENABLED BEFORE CHANGES**

```js
{
  title: Load Test without Changes,
  url: 'http://mysite.local',
  socketPath: undefined,
  connections: 12,
  sampleInt: 1000,
  pipelining: 1,
  workers: undefined,
  duration: 30.04,
  samples: 30,
  start: 2023-08-15T12:15:43.326Z,
  finish: 2023-08-15T12:16:13.362Z,
  errors: 0,
  timeouts: 0,
  mismatches: 0,
  non2xx: 0,
  resets: 0,
  '1xx': 0,
  '2xx': 226,
  '3xx': 0,
  '4xx': 0,
  '5xx': 0,
  statusCodeStats: { '200': { count: 226 } },
  latency: {
    average: 1544.7,
    mean: 1544.7,
    stddev: 181.41,
    min: 266,
    max: 1627,
    p0_001: 266,
    p0_01: 266,
    p0_1: 266,
    p1: 522,
    p2_5: 785,
    p10: 1563,
    p25: 1567,
    p50: 1575,
    p75: 1586,
    p90: 1602,
    p97_5: 1620,
    p99: 1625,
    p99_9: 1627,
    p99_99: 1627,
    p99_999: 1627,
    totalCount: 226
  },
  requests: {
    average: 7.54,
    mean: 7.54,
    stddev: 0.85,
    min: 6,
    max: 8,
    total: 226,
    p0_001: 6,
    p0_01: 6,
    p0_1: 6,
    p1: 6,
    p2_5: 6,
    p10: 6,
    p25: 8,
    p50: 8,
    p75: 8,
    p90: 8,
    p97_5: 8,
    p99: 8,
    p99_9: 8,
    p99_99: 8,
    p99_999: 8,
    sent: 238
  },
  throughput: {
    average: 88808.54,
    mean: 88808.54,
    stddev: 9961.38,
    min: 70740,
    max: 94320,
    total: 2664540,
    p0_001: 70783,
    p0_01: 70783,
    p0_1: 70783,
    p1: 70783,
    p2_5: 70783,
    p10: 70783,
    p25: 94335,
    p50: 94335,
    p75: 94335,
    p90: 94335,
    p97_5: 94335,
    p99: 94335,
    p99_9: 94335,
    p99_99: 94335,
    p99_999: 94335
  }
}
```

**PLUGIN ENABLED AFTER CHANGES**

```js
{
  title: Load Test with Changes,
  url: 'http://mysite.local',
  socketPath: undefined,
  connections: 12,
  sampleInt: 1000,
  pipelining: 1,
  workers: undefined,
  duration: 30.04,
  samples: 30,
  start: 2023-08-15T12:17:15.446Z,
  finish: 2023-08-15T12:17:45.485Z,
  errors: 0,
  timeouts: 0,
  mismatches: 0,
  non2xx: 0,
  resets: 0,
  '1xx': 0,
  '2xx': 375,
  '3xx': 0,
  '4xx': 0,
  '5xx': 0,
  statusCodeStats: { '200': { count: 375 } },
  latency: {
    average: 945.08,
    mean: 945.08,
    stddev: 86.76,
    min: 166,
    max: 1039,
    p0_001: 166,
    p0_01: 166,
    p0_1: 166,
    p1: 327,
    p2_5: 836,
    p10: 925,
    p25: 938,
    p50: 957,
    p75: 972,
    p90: 986,
    p97_5: 1009,
    p99: 1026,
    p99_9: 1039,
    p99_99: 1039,
    p99_999: 1039,
    totalCount: 375
  },
  requests: {
    average: 12.5,
    mean: 12.5,
    stddev: 0.81,
    min: 12,
    max: 14,
    total: 375,
    p0_001: 12,
    p0_01: 12,
    p0_1: 12,
    p1: 12,
    p2_5: 12,
    p10: 12,
    p25: 12,
    p50: 12,
    p75: 13,
    p90: 14,
    p97_5: 14,
    p99: 14,
    p99_9: 14,
    p99_99: 14,
    p99_999: 14,
    sent: 387
  },
  throughput: {
    average: 147392,
    mean: 147392,
    stddev: 9494.12,
    min: 141480,
    max: 165060,
    total: 4421250,
    p0_001: 141567,
    p0_01: 141567,
    p0_1: 141567,
    p1: 141567,
    p2_5: 141567,
    p10: 141567,
    p25: 141567,
    p50: 141567,
    p75: 153343,
    p90: 165119,
    p97_5: 165119,
    p99: 165119,
    p99_9: 165119,
    p99_99: 165119,
    p99_999: 165119
  }
}
```

**PLUGIN ENABLED AFTER CHANGES AND NOT QUERYING editorBlocks**

Sample request:
```graphql
{
  posts {
    nodes {
      content
    }
  }
}
```


```js
{
  title: 'Load Test with Changes and not querying editorBlocks',
  url: 'http://mysite.local',
  socketPath: undefined,
  connections: 12,
  sampleInt: 1000,
  pipelining: 1,
  workers: undefined,
  duration: 30.04,
  samples: 30,
  start: 2023-08-15T12:53:34.574Z,
  finish: 2023-08-15T12:54:04.615Z,
  errors: 0,
  timeouts: 0,
  mismatches: 0,
  non2xx: 0,
  resets: 0,
  '1xx': 0,
  '2xx': 684,
  '3xx': 0,
  '4xx': 0,
  '5xx': 0,
  statusCodeStats: { '200': { count: 684 } },
  latency: {
    average: 521.04,
    mean: 521.04,
    stddev: 54.52,
    min: 100,
    max: 650,
    p0_001: 100,
    p0_01: 100,
    p0_1: 100,
    p1: 382,
    p2_5: 475,
    p10: 478,
    p25: 486,
    p50: 513,
    p75: 552,
    p90: 591,
    p97_5: 627,
    p99: 641,
    p99_9: 650,
    p99_99: 650,
    p99_999: 650,
    totalCount: 684
  },
  requests: {
    average: 22.8,
    mean: 22.8,
    stddev: 1.98,
    min: 18,
    max: 26,
    total: 684,
    p0_001: 18,
    p0_01: 18,
    p0_1: 18,
    p1: 18,
    p2_5: 18,
    p10: 20,
    p25: 22,
    p50: 24,
    p75: 24,
    p90: 24,
    p97_5: 26,
    p99: 26,
    p99_9: 26,
    p99_99: 26,
    p99_999: 26,
    sent: 696
  },
  throughput: {
    average: 269162.67,
    mean: 269162.67,
    stddev: 23290.88,
    min: 212526,
    max: 306982,
    total: 8075988,
    p0_001: 212607,
    p0_01: 212607,
    p0_1: 212607,
    p1: 212607,
    p2_5: 212607,
    p10: 236159,
    p25: 259839,
    p50: 283391,
    p75: 283391,
    p90: 283391,
    p97_5: 307199,
    p99: 307199,
    p99_9: 307199,
    p99_99: 307199,
    p99_999: 307199
  }
}
```

**Using eagerlyLoadType:false**

Sample request:
```graphql
{
  posts {
    nodes {
      content
    }
  }
}
```

```js
{
  title: Using eagerlyLoadType:false,
  url: 'http://mysite.local',
  socketPath: undefined,
  connections: 12,
  sampleInt: 1000,
  pipelining: 1,
  workers: undefined,
  duration: 30.04,
  samples: 30,
  start: 2023-08-15T12:57:33.395Z,
  finish: 2023-08-15T12:58:03.432Z,
  errors: 0,
  timeouts: 0,
  mismatches: 0,
  non2xx: 0,
  resets: 0,
  '1xx': 0,
  '2xx': 808,
  '3xx': 0,
  '4xx': 0,
  '5xx': 0,
  statusCodeStats: { '200': { count: 808 } },
  latency: {
    average: 442.63,
    mean: 442.63,
    stddev: 34.61,
    min: 91,
    max: 574,
    p0_001: 91,
    p0_01: 91,
    p0_1: 91,
    p1: 392,
    p2_5: 420,
    p10: 424,
    p25: 429,
    p50: 437,
    p75: 456,
    p90: 472,
    p97_5: 509,
    p99: 542,
    p99_9: 574,
    p99_99: 574,
    p99_999: 574,
    totalCount: 808
  },
  requests: {
    average: 26.94,
    mean: 26.94,
    stddev: 1.34,
    min: 24,
    max: 30,
    total: 808,
    p0_001: 24,
    p0_01: 24,
    p0_1: 24,
    p1: 24,
    p2_5: 24,
    p10: 26,
    p25: 26,
    p50: 26,
    p75: 28,
    p90: 28,
    p97_5: 30,
    p99: 30,
    p99_9: 30,
    p99_99: 30,
    p99_999: 30,
    sent: 820
  },
  throughput: {
    average: 318045.87,
    mean: 318045.87,
    stddev: 15817.09,
    min: 283368,
    max: 354210,
    total: 9540056,
    p0_001: 283391,
    p0_01: 283391,
    p0_1: 283391,
    p1: 283391,
    p2_5: 283391,
    p10: 307199,
    p25: 307199,
    p50: 307199,
    p75: 330751,
    p90: 330751,
    p97_5: 354303,
    p99: 354303,
    p99_9: 354303,
    p99_99: 354303,
    p99_999: 354303
  }
}
```

## Load Testing Summary

**Run Params Legend**

Plugin Enabled BEFORE: X
Plugin Enabled AFTER: W
Plugin Disabled: O
EditorBlocks used: +
EditorBlocks not used: -
eagerLoadType enabled: <
eagerLoadType disabled: >


|  Run Params |  Latency(ms)  |  Req/sec |  % diff from base |
|---|---|---|---|
|  O- | 367 | 972  | 0 |
|  X+< | 544  |  226 | -77%  |
|  W+< | 945  |  375 | -62%  |
|  W-> |  442.63 |    808 | -17%  |
|  W-< | 521  | 684  | -30%  |
|  W+> | 688  | 518  | -47%  |
