### PR TITLE
fix: #159 - ${PostType}EditorBlock Interfaces registered and implemented with different names

### DIFF
--- a/includes/Registry/Registry.php
+++ b/includes/Registry/Registry.php
@@ -221,7 +221,7 @@ final class Registry {
 		// For each Post type
 		foreach ( $supported_post_types as $post_type ) {
 			// Normalize the post type name
-			$type_name = WPGraphQLHelpers::format_type_name( $post_type->name );
+			$type_name = Utils::format_type_name( $post_type->graphql_single_name );
 
 			// retrieve a block_editor_context for the current post type
 			$block_editor_context = WPHelpers::get_block_editor_context( $type_name, $post_id-- );


### PR DESCRIPTION
Instead of using the Post Type's name to register Interface Types, this uses the Post Type's graphql_single_name to register the Interface Types, which is consistent with what is used to implement the Types as Interfaces.

closes #159 