### PR TITLE
Updated readme.txt version with 6.4

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: blakewpe, chriswiegman, joefusco, matthewguywright, TeresaGobble, thdespou, wpengine
 Tags: faustjs, faust, headless, decoupled, gutenberg
 Requires at least: 5.7
-Tested up to: 6.1
+Tested up to: 6.4
 Stable tag: 2.0.0
 Requires PHP: 7.4
 License: GPLv2 or later


### PR DESCRIPTION
I tested our wp-graphql-content-blocks plugin with the [WordPress Beta Tester](https://wordpress.org/extend/plugins/wordpress-beta-tester/) plugin. After uploading this testing plugin, I changed the settings of the plugin to the following to enable v6.4 testing: 

<img width="1159" alt="image" src="https://github.com/wpengine/wp-graphql-content-blocks/assets/50935135/30347501-13c9-4f4d-9747-367079bd3e2c">
I then updated WordPress to version 6.4-RC3:
<img width="697" alt="image" src="https://github.com/wpengine/wp-graphql-content-blocks/assets/50935135/705cdd81-1d53-4b30-800b-e39f2560a08d">

Upon installation of version 6.4-RC3, I pulled up my testing repo, which contains blocks from our blockset command example project, as well as my own customized block. I tested the customized block with the GraphiQL IDE and am still able to perform queries for the block data:

<img width="845" alt="image" src="https://github.com/wpengine/wp-graphql-content-blocks/assets/50935135/99bc8d33-2548-4189-bb87-60ea467f983a">

I examined customized blocks in the editor and on the site previews and noticed that the initial publishing of blocks resulted in the correct display of the blocks on the site:

Editor: 
<img width="799" alt="image" src="https://github.com/wpengine/wp-graphql-content-blocks/assets/50935135/952e42ad-5d53-493f-a0fd-7dc1939b286c">
Site: 
<img width="404" alt="image" src="https://github.com/wpengine/wp-graphql-content-blocks/assets/50935135/94ab2e07-f018-43c6-83b4-4d0f13f6d7aa">

However, previews is not updating with changes to blocks in posts that are already published. This is related to [this bug](https://wpengine.atlassian.net/jira/software/c/projects/MERL/boards/1007/backlog?selectedIssue=MERL-1256&text=preview). 

https://github.com/wpengine/wp-graphql-content-blocks/assets/50935135/ae5f726b-b4c1-42b3-9e49-b3c879209885

Open questions: 
- If the preview is not reflecting the block changes after editing published blocks, is there a way for me to ensure the save functionality is still working?
- Are there any other features of the wp-graphql-content-blocks plugin that should be checked?

Testing instructions: 

- Go to the [WordPress Beta Tester](https://wordpress.org/extend/plugins/wordpress-beta-tester/) plugin and add it to your testing site. 
- Follow the steps I took above to toggle the site to v6.4. 
- Go to the GraphQL IDE and examine the editorBlocks and fields.
- Add a block to the editor in a new post.
- Note that upon save, the block shows correctly on the site. 

