### PR TITLE
Add support for querying array type query data from blocks

### DIFF
--- a/.changeset/ten-dolphins-smash.md
+++ b/.changeset/ten-dolphins-smash.md
@@ -1,5 +1,5 @@
 ---
-"@wpengine/wp-graphql-content-blocks": minor
+"@wpengine/wp-graphql-content-blocks": major
 ---
 
 Feature: Add support for querying array type query data from blocks

--- a/.changeset/ten-dolphins-smash.md
+++ b/.changeset/ten-dolphins-smash.md
@@ -1,0 +1,7 @@
+---
+"@wpengine/wp-graphql-content-blocks": minor
+---
+
+Feature: Add support for querying array type query data from blocks
+
+Query source block attribute types are supported. See: https://developer.wordpress.org/block-editor/reference-guides/block-api/block-attributes/#query-source

--- a/includes/Blocks/Block.php
+++ b/includes/Blocks/Block.php
@@ -81,13 +81,14 @@ class Block {
 	 * Registers the block attributes GraphQL type and adds it as a field on the Block.
 	 */
 	private function register_block_attributes_as_fields(): void {
+		// Grab any additional block attributes attached into the class itself
 		if ( isset( $this->additional_block_attributes ) ) {
-			$block_attributes       = ! empty( $this->block_attributes ) ? array_merge( $this->block_attributes, $this->additional_block_attributes ) : $this->additional_block_attributes;
-			$block_attribute_fields = $this->get_block_attribute_fields( $block_attributes );
+			$block_attributes = ! empty( $this->block_attributes ) ? array_merge( $this->block_attributes, $this->additional_block_attributes ) : $this->additional_block_attributes;
 		} else {
-			$block_attribute_fields = $this->get_block_attribute_fields( $this->block_attributes );
+			$block_attributes = $this->block_attributes;
 		}
-
+		$block_attribute_fields = $this->get_block_attribute_fields( $block_attributes, $this->type_name . 'Attributes' );
+		// For each attribute, register a new object type and attach it to the block type as a field
 		if ( ! empty( $block_attribute_fields ) ) {
 			$block_attribute_type_name = $this->type_name . 'Attributes';
 			register_graphql_object_type(
@@ -122,65 +123,179 @@ class Block {
 	}
 
 	/**
+	 * Returns the type of the block attribute
+	 * 
+	 * @param string $name The block name
+	 * @param object $attribute The block attribute config
+	 * @param string $prefix Current prefix string to use for the get_query_type
+	 */
+	private function get_attribute_type( $name, $attribute, $prefix ) {
+		$type = null;
+
+		if ( isset( $attribute['type'] ) ) {
+			switch ( $attribute['type'] ) {
+				case 'string':
+					$type = 'String';
+					break;
+				case 'boolean':
+					$type = 'Boolean';
+					break;
+				case 'number':
+					$type = 'Float';
+					break;
+				case 'integer':
+					$type = 'Int';
+					break;
+				case 'array':
+					if ( isset( $attribute['query'] ) ) {
+						$type = [ 'list_of' => $this->get_query_type( $name, $attribute['query'], $prefix ) ];
+					} elseif ( isset( $attribute['items'] ) ) {
+						$of_type = $this->get_attribute_type( $name, $attribute['items'], $prefix );
+
+						if ( null !== $of_type ) {
+							$type = [ 'list_of' => $of_type ];
+						} else {
+							$type = Scalar::get_block_attributes_array_type_name();
+						}
+					}
+					else {
+						$type = Scalar::get_block_attributes_array_type_name();
+					}
+					break;
+				case 'object':
+					$type = Scalar::get_block_attributes_object_type_name();
+					break;
+			}
+		} elseif ( isset( $attribute['source'] ) ) {
+			$type = 'String';
+		}
+
+		if ( null !== $type ) {
+			$default_value = $attribute['default'] ?? null;
+
+			if ( isset( $default_value ) ) {
+				$type = [ 'non_null' => $type ];
+			}
+		}
+
+		return $type;
+	}
+
+	/**
 	 * Gets the WPGraphQL field registration config for the block attributes.
 	 *
 	 * @param ?array $block_attributes The block attributes.
+	 * @param string $prefix The current prefix string to use for the get_query_type
 	 */
-	private function get_block_attribute_fields( ?array $block_attributes ): array {
-		$block_attribute_fields = [];
+	private function get_block_attribute_fields( ?array $block_attributes, $prefix = null ): array {
+		$fields = [];
 
 		// Bail early if no attributes are defined.
 		if ( null === $block_attributes ) {
-			return $block_attribute_fields;
+			return $fields;
 		}
 
 		foreach ( $block_attributes as $attribute_name => $attribute_config ) {
-			$graphql_type = null;
-
-			if ( ! isset( $attribute_config['type'] ) ) {
-				return $block_attribute_fields;
-			}
-
-			switch ( $attribute_config['type'] ) {
-				case 'string':
-					$graphql_type = 'String';
-					break;
-				case 'number':
-					$graphql_type = 'Float';
-					break;
-				case 'integer':
-					$graphql_type = 'Int';
-					break;
-				case 'boolean':
-					$graphql_type = 'Boolean';
-					break;
-				case 'array':
-				case 'object':
-					$graphql_type = Scalar::get_block_attributes_object_type_name();
-					break;
-			}
-
-			// Skip if there's no valid type.
+			$graphql_type = self::get_attribute_type( $attribute_name, $attribute_config, $prefix );
 			if ( empty( $graphql_type ) ) {
 				continue;
 			}
-
 			// Create the field config.
-			$block_attribute_fields[ Utils::format_field_name( $attribute_name ) ] = [
+			$fields[ Utils::format_field_name( $attribute_name ) ] = [
 				'type'        => $graphql_type,
 				'description' => sprintf(
 					// translators: %1$s is the attribute name, %2$s is the block name.
-					__( 'The "%1$s" field on the "%2$s" block', 'wp-graphql-content-blocks' ),
+					__( 'The "%1$s" field on the "%2$s" block or block attributes', 'wp-graphql-content-blocks' ),
 					$attribute_name,
-					$this->type_name
+					$prefix
 				),
 				'resolve'     => function ( $block ) use ( $attribute_name, $attribute_config ) {
-					return $this->resolve_block_attributes( $block, $attribute_name, $attribute_config );
+					$config = [
+						$attribute_name => $attribute_config,
+					];
+					$result = $this->resolve_block_attributes_recursive( $block['attrs'], wp_unslash( render_block( $block ) ), $config );
+					return $result[ $attribute_name ];
 				},
 			];
 		}//end foreach
 
-		return $block_attribute_fields;
+		return $fields;
+	}
+	
+	/**
+	 * Returns the type of the block query attribute
+	 * 
+	 * @param string $name The block name
+	 * @param array  $query The block query config
+	 * @param string $prefix The current prefix string to use for registering the new query attribute type
+	 */
+	private function get_query_type( $name, $query, $prefix ) {
+		$type = $prefix . ucfirst( $name );
+
+		$fields = $this->create_attributes_fields( $query, $type );
+	
+		register_graphql_object_type(
+			$type,
+			[
+				'fields'      => $fields,
+				'description' => sprintf(
+					// translators: %1$s is the attribute name, %2$s is the block attributes field.
+					__( 'The "%1$s" field on the "%2$s" block attribute field', 'wp-graphql-content-blocks' ),
+					$type,
+					$prefix
+				),
+			]
+		);
+
+		return $type;
+	}
+
+	/**
+	 * Creates the new attribute fields for query types
+	 * 
+	 * @param array  $attributes The query attributes config
+	 * @param string $prefix The current prefix string to use for registering the new query attribute type
+	 */
+	private function create_attributes_fields( $attributes, $prefix ) {
+		$fields = [];
+		foreach ( $attributes as $name => $attribute ) {
+			$type = $this->get_attribute_type( $name, $attribute, $prefix );
+
+			if ( isset( $type ) ) {
+				$default_value = $attribute['default'] ?? null;
+
+				$fields[ Utils::format_field_name( $name ) ] = [
+					'type'    => $type,
+					'resolve' => function ( $attributes ) use ( $name, $default_value ) {
+						$value = $attributes[ $name ] ?? $default_value;
+						return $this->normalize_attribute_value( $value, $attributes['__type'][ $name ]['type'] );
+					},
+				];
+			}
+		}
+
+		return $fields;
+	}
+
+	/**
+	 * Normalizes the value of the attribute
+	 * 
+	 * @param array|string $value The value
+	 * @param string       $type The type of the value
+	 */
+	private function normalize_attribute_value( $value, $type ) {
+		switch ( $type ) {
+			case 'string':
+				return (string) $value;
+			case 'number':
+				return (float) $value;
+			case 'boolean':
+				return (bool) $value;
+			case 'integer':
+				return (int) $value;
+			default:
+				return $value;
+		}
 	}
 
 	/**
@@ -202,7 +317,7 @@ class Block {
 	}
 
 	/**
-	 * Register the Type for the block
+	 * Register the Type for the block. This happens after all other object types are already registered.
 	 */
 	private function register_type(): void {
 		/**
@@ -237,72 +352,91 @@ class Block {
 	}
 
 	/**
-	 * Returns the necessary block data to resolve the block attributes.
-	 *
-	 * @param array  $block            The block data passed to the resolver.
-	 * @param string $attribute_name   The name of the attribute to resolve.
-	 * @param array  $attribute_config The config for the attribute.
+	 * Resolved the value of the block attributes based on the specified config
+	 * 
+	 * @param array  $attributes The block current attributes value
+	 * @param string $html The block rendered html
+	 * @param array  $config The block current attribute configuration
 	 */
-	private function resolve_block_attributes( $block, $attribute_name, $attribute_config ) {
-		// Get default value.
-		$default = isset( $attribute_config['default'] ) ? $attribute_config['default'] : null;
-		// Case when only source defined: Classic Blocks
-		if ( isset( $attribute_config['source'] ) && ! isset( $attribute_config['selector'] ) ) {
-			$rendered_block = wp_unslash( render_block( $block ) );
-			$value          = null;
-			if ( empty( $rendered_block ) ) {
-				return $value;
-			}
-			switch ( $attribute_config['source'] ) {
+	private function resolve_block_attributes_recursive( $attributes, $html, $config ) {
+		$result = [];
+		foreach ( $config as $key => $value ) {
+			// Get default value.
+			$default = isset( $value['default'] ) ? $value['default'] : null;
+			$source  = $value['source'] ?? null;
+			switch ( $source ) {
 				case 'html':
-					$value = $rendered_block;
-					break;
-			}
-			return $value;
-		}
-		// Case when both selector and source are defined
-		if ( isset( $attribute_config['selector'], $attribute_config['source'] ) ) {
-			$rendered_block = wp_unslash( render_block( $block ) );
-			$value          = null;
-			if ( empty( $rendered_block ) ) {
-				return $value;
-			}
-
-			switch ( $attribute_config['source'] ) {
-				case 'attribute':
-					$value = DOMHelpers::parseAttribute( $rendered_block, $attribute_config['selector'], $attribute_config['attribute'], $default );
-					break;
-				case 'html':
-					$value = DOMHelpers::parseHTML( $rendered_block, $attribute_config['selector'], $default );
-
-					if ( isset( $attribute_config['multiline'] ) && ! empty( $value ) ) {
-						$value = DOMHelpers::getElementsFromHTML( $value, $attribute_config['multiline'] );
+					if ( ! isset( $value['selector'] ) ) {
+						$result[ $key ] = $this->parse_single_source( $html, $source );
+					} else {
+						$result[ $key ] = DOMHelpers::parseHTML( $html, $value['selector'] );
+	
+						if ( isset( $value['multiline'] ) && ! empty( $result[ $key ] ) ) {
+							$result[ $key ] = DOMHelpers::getElementsFromHTML( $result[ $key ], $value['multiline'] );
+						}
 					}
-
+					break;
+				case 'attribute':
+					$result[ $key ] = DOMHelpers::parseAttribute( $html, $value['selector'], $value['attribute'], $value );
 					break;
 				case 'text':
-					$value = DOMHelpers::getTextFromSelector( $rendered_block, $attribute_config['selector'], $default );
-
+					$result[ $key ] = DOMHelpers::parseText( $html, $value['selector'] );
 					break;
-			}//end switch
-			// Post processing of return value based on configured type
-			switch ( $attribute_config['type'] ) {
-				case 'integer':
-					$value = intval( $value );
-					break;
-				case 'boolean':
-					// If the value is empty or false return
-					if ( is_null( $value ) || false === $value ) {
-						break;
+				case 'query':
+					$temp = [];
+					foreach ( DOMHelpers::findNodes( $html, $value['selector'] ) as $source_node ) {
+						foreach ( $value['query'] as $q_key => $q_value ) {
+							$temp_config    = [
+								$q_key => $q_value,
+							];
+							$res            = $this->resolve_block_attributes_recursive( $attributes, $source_node->html(), $temp_config );
+							$temp[ $q_key ] = $res[ $q_key ];
+						}
+						$result[ $key ][] = $temp;
 					}
-					// Otherwise it's truthy
-					$value = true;
 					break;
 			}
+			// Post processing of return value based on configured type
+			switch ( $value['type'] ) {
+				case 'integer':
+					$result[ $key ] = intval( $result[ $key ] );
+					break;
+				case 'boolean':
+					if ( false === $result[ $key ] ) {
+						break;
+					}
+					if ( is_null( $result[ $key ] ) ) {
+						$result[ $key ] = false;
+						break;
+					}
+					$result[ $key ] = true;
+					break;
+			}
+			
+			if ( empty( $result[ $key ] ) ) {
+				$result[ $key ] = $attributes[ $key ] ?? $default;
+			}
+		}
+		
+		return $result;
+	}
 
+	/**
+	 * Parses the block content of a source only block type
+	 * 
+	 * @param string $html The html value
+	 * @param string $source The source type
+	 */
+	private function parse_single_source( $html, $source ) {
+		$value = null;
+		if ( empty( $html ) ) {
 			return $value;
-		}//end if
-
-		return $block['attrs'][ $attribute_name ] ?? $default;
+		}
+		switch ( $source ) {
+			case 'html':
+				$value = $html;
+				break;
+		}
+		return $value;
 	}
 }

--- a/includes/Blocks/Block.php
+++ b/includes/Blocks/Block.php
@@ -373,7 +373,7 @@ class Block {
 		$result = [];
 		foreach ( $config as $key => $value ) {
 			// Get default value.
-			$default = isset( $value['default'] ) ? $value['default'] : null;
+			$default = $value['default'] ?? null;
 			$source  = $value['source'] ?? null;
 			switch ( $source ) {
 				case 'html':

--- a/includes/Blocks/Block.php
+++ b/includes/Blocks/Block.php
@@ -272,8 +272,14 @@ class Block {
 				$default_value = $attribute['default'] ?? null;
 
 				$fields[ Utils::format_field_name( $name ) ] = [
-					'type'    => $type,
-					'resolve' => function ( $attributes ) use ( $name, $default_value ) {
+					'type'        => $type,
+					'description' => sprintf(
+						// translators: %1$s is the attribute name, %2$s is the block attributes field.
+						__( 'The "%1$s" field on the "%2$s" block attribute field', 'wp-graphql-content-blocks' ),
+						$name,
+						$prefix
+					),
+					'resolve'     => function ( $attributes ) use ( $name, $default_value ) {
 						$value = $attributes[ $name ] ?? $default_value;
 						return $this->normalize_attribute_value( $value, $attributes['__type'][ $name ]['type'] );
 					},

--- a/includes/Blocks/Block.php
+++ b/includes/Blocks/Block.php
@@ -190,7 +190,7 @@ class Block {
 	 * 
 	 * @return array
 	 */
-	private function get_block_attribute_fields( ?array $block_attributes, $prefix = null ): array {
+	private function get_block_attribute_fields( ?array $block_attributes, $prefix = '' ): array {
 		$fields = [];
 
 		// Bail early if no attributes are defined.

--- a/includes/Blocks/Block.php
+++ b/includes/Blocks/Block.php
@@ -157,8 +157,7 @@ class Block {
 						} else {
 							$type = Scalar::get_block_attributes_array_type_name();
 						}
-					}
-					else {
+					} else {
 						$type = Scalar::get_block_attributes_array_type_name();
 					}
 					break;

--- a/includes/Blocks/Block.php
+++ b/includes/Blocks/Block.php
@@ -128,8 +128,10 @@ class Block {
 	 * @param string $name The block name
 	 * @param object $attribute The block attribute config
 	 * @param string $prefix Current prefix string to use for the get_query_type
+	 * 
+	 * @return mixed
 	 */
-	private function get_attribute_type( $name, $attribute, $prefix ): mixed {
+	private function get_attribute_type( $name, $attribute, $prefix ) {
 		$type = null;
 
 		if ( isset( $attribute['type'] ) ) {
@@ -183,8 +185,8 @@ class Block {
 	/**
 	 * Gets the WPGraphQL field registration config for the block attributes.
 	 *
-	 * @param ?array $block_attributes The block attributes.
-	 * @param string $prefix The current prefix string to use for the get_query_type
+	 * @param ?array      $block_attributes The block attributes.
+	 * @param string|null $prefix The current prefix string to use for the get_query_type
 	 * 
 	 * @return array
 	 */
@@ -287,8 +289,10 @@ class Block {
 	 * 
 	 * @param array|string $value The value
 	 * @param string       $type The type of the value
+	 * 
+	 * @return mixed
 	 */
-	private function normalize_attribute_value( $value, $type ): mixed {
+	private function normalize_attribute_value( $value, $type ) {
 		switch ( $type ) {
 			case 'string':
 				return (string) $value;
@@ -433,8 +437,10 @@ class Block {
 	 * 
 	 * @param string $html The html value
 	 * @param string $source The source type
+	 * 
+	 * @return string|null
 	 */
-	private function parse_single_source( $html, $source ): string|null {
+	private function parse_single_source( $html, $source ) {
 		$value = null;
 		if ( empty( $html ) ) {
 			return $value;

--- a/includes/Blocks/Block.php
+++ b/includes/Blocks/Block.php
@@ -129,7 +129,7 @@ class Block {
 	 * @param object $attribute The block attribute config
 	 * @param string $prefix Current prefix string to use for the get_query_type
 	 */
-	private function get_attribute_type( $name, $attribute, $prefix ) {
+	private function get_attribute_type( $name, $attribute, $prefix ): mixed {
 		$type = null;
 
 		if ( isset( $attribute['type'] ) ) {
@@ -185,6 +185,8 @@ class Block {
 	 *
 	 * @param ?array $block_attributes The block attributes.
 	 * @param string $prefix The current prefix string to use for the get_query_type
+	 * 
+	 * @return array
 	 */
 	private function get_block_attribute_fields( ?array $block_attributes, $prefix = null ): array {
 		$fields = [];
@@ -193,7 +195,7 @@ class Block {
 		if ( null === $block_attributes ) {
 			return $fields;
 		}
-
+		
 		foreach ( $block_attributes as $attribute_name => $attribute_config ) {
 			$graphql_type = self::get_attribute_type( $attribute_name, $attribute_config, $prefix );
 
@@ -230,7 +232,7 @@ class Block {
 	 * @param array  $query The block query config
 	 * @param string $prefix The current prefix string to use for registering the new query attribute type
 	 */
-	private function get_query_type( $name, $query, $prefix ) {
+	private function get_query_type( $name, $query, $prefix ): string {
 		$type = $prefix . ucfirst( $name );
 
 		$fields = $this->create_attributes_fields( $query, $type );
@@ -256,8 +258,10 @@ class Block {
 	 * 
 	 * @param array  $attributes The query attributes config
 	 * @param string $prefix The current prefix string to use for registering the new query attribute type
+	 * 
+	 * @return array
 	 */
-	private function create_attributes_fields( $attributes, $prefix ) {
+	private function create_attributes_fields( $attributes, $prefix ): array {
 		$fields = [];
 		foreach ( $attributes as $name => $attribute ) {
 			$type = $this->get_attribute_type( $name, $attribute, $prefix );
@@ -284,7 +288,7 @@ class Block {
 	 * @param array|string $value The value
 	 * @param string       $type The type of the value
 	 */
-	private function normalize_attribute_value( $value, $type ) {
+	private function normalize_attribute_value( $value, $type ): mixed {
 		switch ( $type ) {
 			case 'string':
 				return (string) $value;
@@ -358,8 +362,10 @@ class Block {
 	 * @param array  $attributes The block current attributes value
 	 * @param string $html The block rendered html
 	 * @param array  $config The block current attribute configuration
+	 * 
+	 * @return array
 	 */
-	private function resolve_block_attributes_recursive( $attributes, $html, $config ) {
+	private function resolve_block_attributes_recursive( $attributes, $html, $config ): array {
 		$result = [];
 		foreach ( $config as $key => $value ) {
 			// Get default value.
@@ -428,14 +434,14 @@ class Block {
 	 * @param string $html The html value
 	 * @param string $source The source type
 	 */
-	private function parse_single_source( $html, $source ) {
+	private function parse_single_source( $html, $source ): string|null {
 		$value = null;
 		if ( empty( $html ) ) {
 			return $value;
 		}
 		switch ( $source ) {
 			case 'html':
-				$value = $html;
+				$value = DOMHelpers::findNodes( $html )->innerHTML();
 				break;
 		}
 		return $value;

--- a/includes/Blocks/Block.php
+++ b/includes/Blocks/Block.php
@@ -197,6 +197,7 @@ class Block {
 
 		foreach ( $block_attributes as $attribute_name => $attribute_config ) {
 			$graphql_type = self::get_attribute_type( $attribute_name, $attribute_config, $prefix );
+
 			if ( empty( $graphql_type ) ) {
 				continue;
 			}
@@ -214,6 +215,7 @@ class Block {
 						$attribute_name => $attribute_config,
 					];
 					$result = $this->resolve_block_attributes_recursive( $block['attrs'], wp_unslash( render_block( $block ) ), $config );
+					
 					return $result[ $attribute_name ];
 				},
 			];

--- a/includes/Blocks/Block.php
+++ b/includes/Blocks/Block.php
@@ -234,7 +234,7 @@ class Block {
 	 * @param array  $query The block query config
 	 * @param string $prefix The current prefix string to use for registering the new query attribute type
 	 */
-	private function get_query_type( $name, $query, $prefix ): string {
+	private function get_query_type( string $name, array $query, string $prefix ): string {
 		$type = $prefix . ucfirst( $name );
 
 		$fields = $this->create_attributes_fields( $query, $type );

--- a/includes/Data/ContentBlocksResolver.php
+++ b/includes/Data/ContentBlocksResolver.php
@@ -84,7 +84,7 @@ final class ContentBlocksResolver {
 			ARRAY_FILTER_USE_BOTH
 		);
 
-		// 1st Level assigning of unique id's and missing blockNames
+		// 2nd Level assigning of unique id's and missing blockNames
 		$parsed_blocks = array_map(
 			static function ( $parsed_block ) {
 				$parsed_block['clientId'] = uniqid();

--- a/includes/Type/Scalar/Scalar.php
+++ b/includes/Type/Scalar/Scalar.php
@@ -45,7 +45,7 @@ final class Scalar {
 	/**
 	 * Return type name of BlockAttributesArray.
 	 */
-	public static function get_block_attributes_array_type_name() {
+	public static function get_block_attributes_array_type_name(): string {
 		return 'BlockAttributesArray';
 	}
 }

--- a/includes/Type/Scalar/Scalar.php
+++ b/includes/Type/Scalar/Scalar.php
@@ -24,6 +24,15 @@ final class Scalar {
 				},
 			]
 		);
+		register_graphql_scalar(
+			'BlockAttributesArray',
+			[
+				'description' => __( 'Generic Array Scalar Type', 'wp-graphql-content-blocks' ),
+				'serialize'   => static function ( $value ) {
+					return wp_json_encode( $value );
+				},
+			]
+		);
 	}
 
 	/**
@@ -31,5 +40,12 @@ final class Scalar {
 	 */
 	public static function get_block_attributes_object_type_name(): string {
 		return 'BlockAttributesObject';
+	}
+
+	/**
+	 * Return type name of BlockAttributesArray.
+	 */
+	public static function get_block_attributes_array_type_name() {
+		return 'BlockAttributesArray';
 	}
 }

--- a/includes/Utilities/DomHelpers.php
+++ b/includes/Utilities/DomHelpers.php
@@ -136,7 +136,7 @@ final class DOMHelpers {
 	 * @param string      $html The HTML string to parse.
 	 * @param string|null $selector The selector to use.
 	 *
-	 * @return \DOMElement[]
+	 * @return \DOMElement[]|\WPGraphQL\ContentBlocks\Utilities\DOMElement
 	 */
 	public static function findNodes( $html, $selector = null ) {
 		$value = null;

--- a/includes/Utilities/DomHelpers.php
+++ b/includes/Utilities/DomHelpers.php
@@ -139,12 +139,10 @@ final class DOMHelpers {
 	 * @return \DOMElement[]|\DOMElement
 	 */
 	public static function findNodes( $html, $selector = null ) {
-		$value = null;
 		// Bail early if there's no html to parse.
 		if ( empty( trim( $html ) ) ) {
-			return $value;
+			return null;
 		}
-
 		$doc = new Document( $html );
 		// <html><body>$html</body></html>
 		$elem = $doc->find( '*' )[2];

--- a/includes/Utilities/DomHelpers.php
+++ b/includes/Utilities/DomHelpers.php
@@ -23,11 +23,15 @@ final class DOMHelpers {
 	 *
 	 * @return string|null extracted attribute
 	 */
-	public static function parseAttribute( $html, $selector, $attribute, $default_value = null ): ?string {
+	public static function parseAttribute( $html, $selector = null, $attribute, $default_value = null ): ?string {
 		$doc = new Document();
 		$doc->loadHTML( $html );
 		if ( '*' === $selector ) {
 			$selector = '*[' . $attribute . ']';
+		}
+
+		if ( empty( $selector ) ) {
+			$selector = '*';
 		}
 		$node          = $doc->find( $selector );
 		$default_value = isset( $default_value ) ? $default_value : null;
@@ -112,7 +116,7 @@ final class DOMHelpers {
 	 *
 	 * @return string|null The text content of the selector if found.
 	 */
-	public static function getTextFromSelector( $html, $selector ) {
+	public static function parseText( $html, $selector ) {
 		$doc = new Document();
 		$doc->loadHTML( $html );
 		$nodes = $doc->find( $selector );
@@ -124,5 +128,29 @@ final class DOMHelpers {
 		// Returns the element's "textContent"
 		// https://developer.mozilla.org/en-US/docs/Web/API/Node/textContent
 		return $nodes[0]->text();
+	}
+
+	/**
+	 * Parses the html into DOMElement and searches the DOM tree for a given XPath expression or CSS selector.
+	 *
+	 * @param string      $html The HTML string to parse.
+	 * @param string|null $selector The selector to use.
+	 *
+	 * @return \WPGraphQL\ContentBlocks\Utilities\Element[]|\WPGraphQL\ContentBlocks\Utilities\DOMElement[]
+	 */
+	public static function findNodes( $html, $selector = null ) {
+		$value = null;
+		// Bail early if there's no html to parse.
+		if ( empty( trim( $html ) ) ) {
+			return $value;
+		}
+
+		$doc = new Document( $html );
+		// <html><body>$html</body></html>
+		$elem = $doc->find( '*' )[2];
+		if ( $selector ) {
+			$elem = $doc->find( $selector );
+		}
+		return $elem;
 	}
 }

--- a/includes/Utilities/DomHelpers.php
+++ b/includes/Utilities/DomHelpers.php
@@ -23,7 +23,7 @@ final class DOMHelpers {
 	 *
 	 * @return string|null extracted attribute
 	 */
-	public static function parseAttribute( $html, $selector = null, $attribute, $default_value = null ): ?string {
+	public static function parseAttribute( $html, $selector = '', $attribute, $default_value = null ): ?string {
 		$doc = new Document();
 		$doc->loadHTML( $html );
 		if ( '*' === $selector ) {

--- a/includes/Utilities/DomHelpers.php
+++ b/includes/Utilities/DomHelpers.php
@@ -136,7 +136,7 @@ final class DOMHelpers {
 	 * @param string      $html The HTML string to parse.
 	 * @param string|null $selector The selector to use.
 	 *
-	 * @return \DOMElement[]|\WPGraphQL\ContentBlocks\Utilities\DOMElement
+	 * @return \DOMElement[]|\DOMElement
 	 */
 	public static function findNodes( $html, $selector = null ) {
 		$value = null;

--- a/includes/Utilities/DomHelpers.php
+++ b/includes/Utilities/DomHelpers.php
@@ -23,7 +23,7 @@ final class DOMHelpers {
 	 *
 	 * @return string|null extracted attribute
 	 */
-	public static function parseAttribute( $html, $selector = '', $attribute, $default_value = null ): ?string {
+	public static function parseAttribute( $html, $selector, $attribute, $default_value = null ): ?string {
 		$doc = new Document();
 		$doc->loadHTML( $html );
 		if ( '*' === $selector ) {

--- a/includes/Utilities/DomHelpers.php
+++ b/includes/Utilities/DomHelpers.php
@@ -136,7 +136,7 @@ final class DOMHelpers {
 	 * @param string      $html The HTML string to parse.
 	 * @param string|null $selector The selector to use.
 	 *
-	 * @return \WPGraphQL\ContentBlocks\Utilities\Element[]|\WPGraphQL\ContentBlocks\Utilities\DOMElement[]
+	 * @return \DOMElement[]
 	 */
 	public static function findNodes( $html, $selector = null ) {
 		$value = null;

--- a/tests/unit/blocks/CoreTableTest.php
+++ b/tests/unit/blocks/CoreTableTest.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace WPGraphQL\ContentBlocks\Unit;
+
+final class CoreTableTest extends PluginTestCase {
+    public $instance;
+	public $post_id;
+    
+    public function setUp(): void {
+		parent::setUp();
+		global $wpdb;
+
+		$this->post_id = wp_insert_post(
+			array(
+				'post_title'   => 'Post Title',
+				'post_content' => preg_replace(
+					'/\s+/',
+					' ',
+					trim(
+						'
+                        <!-- wp:table {"hasFixedLayout":true} -->
+                        <figure class="wp-block-table"><table class="has-fixed-layout">
+                        <thead><tr><th>Header 1</th><th>Header 2</th></tr></thead>
+                        <tbody><tr><td></td><td></td></tr><tr><td></td><td></td></tr></tbody><tfoot><tr><td>Footer 1</td><td>Footer 2</td></tr></tfoot></table>
+                        <figcaption class="wp-element-caption">Caption</figcaption></figure>
+                        <!-- /wp:table -->
+                        '
+					)
+				),
+				'post_status'  => 'publish',
+			)
+		);
+	}
+
+    public function tearDown(): void {
+		parent::tearDown();
+		wp_delete_post( $this->post_id, true );
+	}
+
+	public function test_retrieve_core_table_attribute_fields() {
+		$query  = '
+		  fragment CoreTableBlockFragment on CoreTable {
+			attributes {
+              caption
+              align
+              anchor
+			}
+		  }
+
+		  query GetPosts {
+			posts(first: 1) {
+			  nodes {
+				editorBlocks {
+                  name
+				  ...CoreTableBlockFragment
+				}
+			  }
+			}
+		  }
+		';
+		$actual = graphql( array( 'query' => $query ) );
+		$node   = $actual['data']['posts']['nodes'][0];
+        $this->assertEquals( $node['editorBlocks'][0]['name'], 'core/table' );
+        // There should be only one block using that query when not using flat: true
+		$this->assertEquals( count( $node['editorBlocks'] ), 1 );
+        $this->assertEquals( $node['editorBlocks'][0]['attributes'], [
+			"caption" => "Caption",
+            'align' => null,
+            'anchor' => null
+		]); 
+	}
+}

--- a/tests/unit/blocks/CoreTableTest.php
+++ b/tests/unit/blocks/CoreTableTest.php
@@ -5,8 +5,8 @@ namespace WPGraphQL\ContentBlocks\Unit;
 final class CoreTableTest extends PluginTestCase {
     public $instance;
 	public $post_id;
-    
-    public function setUp(): void {
+
+	public function setUp(): void {
 		parent::setUp();
 		global $wpdb;
 
@@ -18,13 +18,13 @@ final class CoreTableTest extends PluginTestCase {
 					' ',
 					trim(
 						'
-                        <!-- wp:table {"hasFixedLayout":true} -->
-                        <figure class="wp-block-table"><table class="has-fixed-layout">
-                        <thead><tr><th>Header 1</th><th>Header 2</th></tr></thead>
-                        <tbody><tr><td></td><td></td></tr><tr><td></td><td></td></tr></tbody><tfoot><tr><td>Footer 1</td><td>Footer 2</td></tr></tfoot></table>
-                        <figcaption class="wp-element-caption">Caption</figcaption></figure>
-                        <!-- /wp:table -->
-                        '
+						<!-- wp:table {"hasFixedLayout":true} -->
+						<figure class="wp-block-table"><table class="has-fixed-layout">
+						<thead><tr><th>Header 1</th><th>Header 2</th></tr></thead>
+						<tbody><tr><td></td><td></td></tr><tr><td></td><td></td></tr></tbody><tfoot><tr><td>Footer 1</td><td>Footer 2</td></tr></tfoot></table>
+						<figcaption class="wp-element-caption">Caption</figcaption></figure>
+						<!-- /wp:table -->
+						'
 					)
 				),
 				'post_status'  => 'publish',
@@ -32,7 +32,7 @@ final class CoreTableTest extends PluginTestCase {
 		);
 	}
 
-    public function tearDown(): void {
+	public function tearDown(): void {
 		parent::tearDown();
 		wp_delete_post( $this->post_id, true );
 	}
@@ -41,9 +41,9 @@ final class CoreTableTest extends PluginTestCase {
 		$query  = '
 		  fragment CoreTableBlockFragment on CoreTable {
 			attributes {
-              caption
-              align
-              anchor
+			  caption
+			  align
+			  anchor
 			}
 		  }
 
@@ -51,7 +51,7 @@ final class CoreTableTest extends PluginTestCase {
 			posts(first: 1) {
 			  nodes {
 				editorBlocks {
-                  name
+				  name
 				  ...CoreTableBlockFragment
 				}
 			  }
@@ -60,13 +60,13 @@ final class CoreTableTest extends PluginTestCase {
 		';
 		$actual = graphql( array( 'query' => $query ) );
 		$node   = $actual['data']['posts']['nodes'][0];
-        $this->assertEquals( $node['editorBlocks'][0]['name'], 'core/table' );
-        // There should be only one block using that query when not using flat: true
+		$this->assertEquals( $node['editorBlocks'][0]['name'], 'core/table' );
+		// There should be only one block using that query when not using flat: true
 		$this->assertEquals( count( $node['editorBlocks'] ), 1 );
-        $this->assertEquals( $node['editorBlocks'][0]['attributes'], [
-			"caption" => "Caption",
-            'align' => null,
-            'anchor' => null
-		]); 
+		$this->assertEquals( $node['editorBlocks'][0]['attributes'], [
+			'caption' => "Caption",
+			'align' => null,
+			'anchor' => null
+		]);
 	}
 }

--- a/tests/unit/blocks/CoreVideoTest.php
+++ b/tests/unit/blocks/CoreVideoTest.php
@@ -80,16 +80,16 @@ final class CoreVideoTest extends PluginTestCase {
             'align' => null,
             'anchor' => null,
             'autoplay' => true,
-            'tracks' => '[]',
-            'muted' => false,
-            'caption' => '',
+            'tracks' => [],
+            'muted' => null,
+            'caption' => null,
             'preload' => 'auto',
             'src' => 'http://mysite.local/wp-content/uploads/2023/07/pexels_videos_1860684-1440p.mp4',
             'playsInline' => true,
-            'controls' => null,
+            'controls' => true,
             'loop' => true,
             'poster' => 'http://mysite.local/wp-content/uploads/2023/05/pexels-egor-komarov-14420089-scaled.jpg',
             'id' => 1636.0,
-		]); 
+		]);
 	}
 }


### PR DESCRIPTION
# Description

Fixes: https://github.com/wpengine/wp-graphql-content-blocks/issues/61

# How to Test

* Create a Table Block and add a header footer and caption
* Add also some cells
* You will be able to query the head, foot and content cells

# Screenshots

<img width="1558" alt="Screenshot 2024-01-02 at 11 31 02" src="https://github.com/wpengine/wp-graphql-content-blocks/assets/328805/e16d312e-8fc0-45ca-a897-78aed119ef15">


