### PR TITLE
Fix paragraph content default attribute

### DIFF
--- a/.changeset/spotty-nails-complain.md
+++ b/.changeset/spotty-nails-complain.md
@@ -1,5 +1,5 @@
 ---
-"@wpengine/wp-graphql-content-blocks": patch
+"@wpengine/wp-graphql-content-blocks": major
 ---
 
-Adds missing default value for content attribute CoreParagraph block
+Adds missing default value for content attribute CoreParagraph and CoreCode blocks. This will make the type of the content field `String!` instead of `String`

--- a/.changeset/spotty-nails-complain.md
+++ b/.changeset/spotty-nails-complain.md
@@ -1,0 +1,5 @@
+---
+"@wpengine/wp-graphql-content-blocks": patch
+---
+
+Adds missing default value for content attribute CoreParagraph block

--- a/includes/Blocks/CoreCode.php
+++ b/includes/Blocks/CoreCode.php
@@ -23,5 +23,11 @@ class CoreCode extends Block {
 			'source'    => 'attribute',
 			'attribute' => 'class',
 		],
+		'content'      => [
+			'type'     => 'string',
+			'selector' => 'code',
+			'source'   => 'html',
+			'default'  => '',
+		],
 	];
 }

--- a/includes/Blocks/CoreParagraph.php
+++ b/includes/Blocks/CoreParagraph.php
@@ -27,6 +27,7 @@ class CoreParagraph extends Block {
 			'type'     => 'string',
 			'selector' => 'p',
 			'source'   => 'html',
+			'default'  => '',
 		],
 	];
 }


### PR DESCRIPTION
# Description

Adds a missing `default` value for the `CoreParagraph` and `CoreCode`  `content` fields.

# Testing

- Go to the GraphQL inspector and Search for the `CoreParagraphAttributes` type. It should be of type `String!` instead of `String`.
- Go to the GraphQL inspector and Search for the `CoreCodeAttributes` type. It should be of type `String!` instead of `String`.

# Screenshots
<img width="379" alt="Screenshot 2024-01-25 at 15 18 53" src="https://github.com/wpengine/wp-graphql-content-blocks/assets/328805/dc5a760c-736f-4205-863d-af8a626018bc">
