### PR TITLE
Bug Fix: parseAttribute function uses wrong default value.

### DIFF
--- a/.changeset/soft-teachers-protect.md
+++ b/.changeset/soft-teachers-protect.md
@@ -1,5 +1,0 @@
----
-"@wpengine/wp-graphql-content-blocks": patch
----
-
-Bug Fix when parsing parseAttribute uses wrong default value and that causes 500 errors.

--- a/.changeset/soft-teachers-protect.md
+++ b/.changeset/soft-teachers-protect.md
@@ -1,0 +1,5 @@
+---
+"@wpengine/wp-graphql-content-blocks": patch
+---
+
+Bug Fix when parsing parseAttribute uses wrong default value and that causes 500 errors.

--- a/includes/Blocks/Block.php
+++ b/includes/Blocks/Block.php
@@ -394,7 +394,7 @@ class Block {
 					}
 					break;
 				case 'attribute':
-					$result[ $key ] = DOMHelpers::parseAttribute( $html, $value['selector'], $value['attribute'], $value );
+					$result[ $key ] = DOMHelpers::parseAttribute( $html, $value['selector'], $value['attribute'], $default );
 					break;
 				case 'text':
 					$result[ $key ] = DOMHelpers::parseText( $html, $value['selector'] );


### PR DESCRIPTION
# Description

This is a Regression bug fix caused by [this PR](https://github.com/wpengine/wp-graphql-content-blocks/pull/176). 
`parseAttribute` would use the wrong default value and thus would return a wrong type for GraphQL which would cause 500 errors.

This PR fixes that issue.

# How to test

1. Use the following post content structure:

<img width="1275" alt="Screenshot 2024-01-30 at 11 28 58" src="https://github.com/wpengine/wp-graphql-content-blocks/assets/328805/dcdd2a06-bf44-4a95-91ad-dff9dc3136a4">


2. Try to perform a full query of this page using the following query:

```
fragment CoreParagraphBlockFragment on CoreParagraph {
  attributes {
    cssClassName
    backgroundColor
    content
    style
    textColor
    fontSize
    fontFamily
    direction
    dropCap
    gradient
    align
  }
}

fragment CoreColumnsBlockFragment on CoreColumns {
  attributes {
    align
    anchor
    layout
    cssClassName
    isStackedOnMobile
    verticalAlignment
    borderColor
    backgroundColor
    fontSize
    fontFamily
    style
    textColor
    gradient
  }
}

fragment CoreColumnBlockFragment on CoreColumn {
  attributes {
    anchor
    borderColor
    backgroundColor
    cssClassName
    fontSize
    fontFamily
    gradient
    layout
    style
    textColor
    verticalAlignment
    width
  }
}

fragment CoreCodeBlockFragment on CoreCode {
  attributes {
    anchor
    backgroundColor
    borderColor
    className
    content
    cssClassName
    fontFamily
    fontSize
    gradient
    lock
    style
    textColor
  }
}

fragment CoreButtonsBlockFragment on CoreButtons {
  attributes {
    cssClassName
    align
    anchor
    fontFamily
    fontSize
    layout
    style
  }
}

fragment CoreButtonBlockFragment on CoreButton {
  attributes {
    anchor
    gradient
    text
    textAlign
    textColor
    style
    fontSize
    fontFamily
    linkTarget
    rel
    url
    backgroundColor
    cssClassName
    linkClassName
  }
}

fragment CoreQuoteBlockFragment on CoreQuote {
  attributes {
    align
    anchor
    backgroundColor
    citation
    className
    fontFamily
    fontSize
    gradient
    lock
    style
    textColor
    value
    cssClassName
  }
}

fragment CoreImageBlockFragment on CoreImage {
  attributes {
    align
    alt
    anchor
    borderColor
    caption
    className
    width
    url
    title
    style
    src
    sizeSlug
    rel
    lock
    linkTarget
    linkDestination
    linkClass
    href
    height
    cssClassName
  }
}

fragment CoreSeparatorBlockFragment on CoreSeparator {
  attributes {
    align
    anchor
    opacity
    gradient
    backgroundColor
    style
    cssClassName
  }
}

fragment CoreListBlockFragment on CoreList {
  attributes {
    anchor
    backgroundColor
    className
    fontFamily
    fontSize
    gradient
    lock
    ordered
    reversed
    start
    style
    textColor
    type
    values
    cssClassName
  }
}

fragment CoreHeadingBlockFragment on CoreHeading {
  attributes {
    align
    anchor
    backgroundColor
    content
    fontFamily
    fontSize
    gradient
    level
    style
    textAlign
    textColor
    cssClassName
  }
}

fragment CreateBlockBlockBFragment on CreateBlockBlockB {
  attributes {
    message
  }
}

query GetPage($databaseId: ID!, $asPreview: Boolean = false) {
  page(id: $databaseId, idType: DATABASE_ID, asPreview: $asPreview) {
    title
    content
    editorBlocks {
      name
      __typename
      renderedHtml
      id: clientId
      parentId: parentClientId
      ...CoreParagraphBlockFragment
      ...CoreColumnsBlockFragment
      ...CoreColumnBlockFragment
      ...CoreCodeBlockFragment
      ...CoreButtonsBlockFragment
      ...CoreButtonBlockFragment
      ...CoreQuoteBlockFragment
      ...CoreImageBlockFragment
      ...CoreSeparatorBlockFragment
      ...CoreListBlockFragment
      ...CoreHeadingBlockFragment
      ...CreateBlockBlockBFragment
    }
  }
}
```

3. Check that there are no Errors printed in the IDE

