### PR TITLE
Schema Linter: reverting schema upload change

### DIFF
--- a/.github/workflows/upload-schema-artifact.yml
+++ b/.github/workflows/upload-schema-artifact.yml
@@ -1,8 +1,10 @@
 name: Upload Schema Artifact
 
 on:
-  release:
-    types: [ published ]
+  workflow_run:
+    workflows: ["Release"]
+    types:
+      - completed
 
 jobs:
   run:


### PR DESCRIPTION
Put the workflow run back into upload-chema-artifact.yml to try to fix the job not running.