### PR TITLE
Changed 'tested up to' in readme.txt to 6.5

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: blakewpe, chriswiegman, joefusco, matthewguywright, TeresaGobble, thdespou, wpengine
 Tags: faustjs, faust, headless, decoupled, gutenberg
 Requires at least: 5.7
-Tested up to: 6.4
+Tested up to: 6.5
 Stable tag: 3.1.2
 Requires PHP: 7.4
 License: GPLv2 or later


### PR DESCRIPTION
## Related Issue(s):

[Internal logistics tracking](https://github.com/orgs/wpengine/projects/13/views/1?pane=issue&itemId=56809132) 

## Testing

I tested our plugin with the [WordPress Beta Tester](https://wordpress.org/extend/plugins/wordpress-beta-tester/) plugin. After uploading this testing plugin, I changed the settings of the plugin to the following to enable v6.5 testing: 

<img width="1159" alt="image" src="https://github.com/wpengine/wp-graphql-content-blocks/assets/50935135/30347501-13c9-4f4d-9747-367079bd3e2c">
I then updated WordPress to version 6.5-RC3:

<img width="683" alt="image" src="https://github.com/wpengine/faustjs/assets/50935135/847f2639-d669-4a45-b7ff-1a4d4d5d3868">

I then headed over to the GraphiQL IDE to test the functionality of the blocks. I am still able to perform queries for the block data, and posts still function normally.

<img width="1115" alt="image" src="https://github.com/wpengine/wp-graphql-content-blocks/assets/50935135/d1ce241b-59b0-4e84-a7ee-a1474ac65477">
