### PR TITLE
chore: stub WP_Post_Type and boostrap main plugin file during phpstan

### DIFF
--- a/.changeset/tough-jokes-turn.md
+++ b/.changeset/tough-jokes-turn.md
@@ -1,0 +1,5 @@
+---
+"@wpengine/wp-graphql-content-blocks": patch
+---
+
+chore: stub WP_Post_Type and boostrap wp-graphql-content-blocks.php when scanning with PHPStan

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -46,17 +46,17 @@ parameters:
 			path: includes/Registry/Registry.php
 
 		-
-			message: "#^Access to an undefined property WP_Post_Type\\:\\:\\$graphql_single_name\\.$#"
-			count: 3
-			path: includes/Registry/Registry.php
-
-		-
 			message: "#^Parameter \\#2 \\$block_spec of static method WPGraphQL\\\\ContentBlocks\\\\Field\\\\BlockSupports\\\\Anchor\\:\\:get_block_attributes_interfaces\\(\\) expects WP_Block_Type, WP_Block_Type\\|null given\\.$#"
 			count: 1
 			path: includes/Registry/Registry.php
 
 		-
 			message: "#^Parameter \\#2 \\$block_spec of static method WPGraphQL\\\\ContentBlocks\\\\Field\\\\BlockSupports\\\\Anchor\\:\\:get_block_interfaces\\(\\) expects WP_Block_Type, WP_Block_Type\\|null given\\.$#"
+			count: 1
+			path: includes/Registry/Registry.php
+
+		-
+			message: "#^Parameter \\#2 \\$type_names of function register_graphql_interfaces_to_types expects array\\<string\\>\\|string, array\\<string\\|null\\> given\\.$#"
 			count: 1
 			path: includes/Registry/Registry.php
 
@@ -76,11 +76,6 @@ parameters:
 			path: includes/Utilities/DomHelpers.php
 
 		-
-			message: "#^If condition is always true\\.$#"
-			count: 1
-			path: includes/Utilities/DomHelpers.php
-
-		-
 			message: "#^Method WPGraphQL\\\\ContentBlocks\\\\Utilities\\\\DOMHelpers\\:\\:findNodes\\(\\) should return array\\<DOMElement\\>\\|DOMElement but returns array\\<DiDom\\\\Element\\|DOMElement\\>\\|DiDom\\\\Element\\|DOMElement\\.$#"
 			count: 1
 			path: includes/Utilities/DomHelpers.php
@@ -91,13 +86,13 @@ parameters:
 			path: includes/Utilities/DomHelpers.php
 
 		-
-			message: "#^Constant WPGRAPHQL_CONTENT_BLOCKS_PATH not found\\.$#"
-			count: 1
+			message: "#^Constant WPGRAPHQL_CONTENT_BLOCKS_PLUGIN_DIR not found\\.$#"
+			count: 4
 			path: includes/WPGraphQLContentBlocks.php
 
 		-
-			message: "#^Constant WPGRAPHQL_CONTENT_BLOCKS_PLUGIN_DIR not found\\.$#"
-			count: 4
+			message: "#^Parameter \\#1 \\$plugin_filename of class EnforceSemVer\\\\EnforceSemVer constructor expects string, null given\\.$#"
+			count: 1
 			path: includes/WPGraphQLContentBlocks.php
 
 		-
@@ -108,16 +103,6 @@ parameters:
 		-
 			message: "#^Cannot access property \\$id on WP_Screen\\|null\\.$#"
 			count: 2
-			path: includes/updates/update-callbacks.php
-
-		-
-			message: "#^Constant WPGRAPHQL_CONTENT_BLOCKS_PATH not found\\.$#"
-			count: 2
-			path: includes/updates/update-callbacks.php
-
-		-
-			message: "#^Constant WPGRAPHQL_CONTENT_BLOCKS_SLUG not found\\.$#"
-			count: 1
 			path: includes/updates/update-callbacks.php
 
 		-
@@ -139,23 +124,3 @@ parameters:
 			message: "#^Function WPGraphQL\\\\ContentBlocks\\\\PluginUpdater\\\\filter_semver_notice_text\\(\\) never returns null so it can be removed from the return type\\.$#"
 			count: 1
 			path: includes/updates/update-callbacks.php
-
-		-
-			message: "#^Variable \\$data in empty\\(\\) always exists and is not falsy\\.$#"
-			count: 1
-			path: includes/updates/update-callbacks.php
-
-		-
-			message: "#^Variable \\$response in empty\\(\\) always exists and is not falsy\\.$#"
-			count: 1
-			path: includes/updates/update-callbacks.php
-
-		-
-			message: "#^Constant WPGRAPHQL_CONTENT_BLOCKS_URL not found\\.$#"
-			count: 1
-			path: includes/updates/update-functions.php
-
-		-
-			message: "#^Variable \\$product_info in empty\\(\\) always exists and is not falsy\\.$#"
-			count: 1
-			path: includes/updates/update-functions.php

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -4,8 +4,13 @@ parameters:
 		level: 8
 		inferPrivatePropertyTypeFromConstructor: true
 		checkMissingIterableValueType: false
+		treatPhpDocTypesAsCertain: false
+		stubFiles:
+			# Simulate added properties
+			- phpstan/class-wp-post-type.php
 		bootstrapFiles:
 			- phpstan/constants.php
+			- wp-graphql-content-blocks.php
 		paths:
 			- wp-graphql-content-blocks.php
 			- includes/

--- a/phpstan/class-wp-post-type.php
+++ b/phpstan/class-wp-post-type.php
@@ -1,0 +1,21 @@
+<?php
+
+/**
+ * @property string $graphql_single_name
+ * @property string $graphql_plural_name
+ * @property bool   $show_in_graphql
+ * @property 'interface'|'object'|'union' $graphql_kind
+ * @property ?callable $graphql_resolve_type
+ * @property array $graphql_connections
+ * @property string[] $graphql_exclude_connections
+ * @property string[] $graphql_interfaces
+ * @property string[] $graphql_exclude_interfaces
+ * @property string[] $graphql_union_types
+ * @property bool $graphql_register_root_field
+ * @property bool $graphql_register_root_connection
+ * @property string[] $graphql_exclude_mutations
+ * @property array $graphql_fields
+ * @property string[] $graphql_exclude_fields
+ */
+final class WP_Post_Type {
+}

--- a/phpstan/constants.php
+++ b/phpstan/constants.php
@@ -5,7 +5,6 @@
  * @package WPGraphQL\ContentBlocks
  */
 
-define( 'WPGRAPHQL_CONTENT_BLOCKS_DIR', '' );
 define( 'WPGRAPHQL_CONTENT_BLOCKS_VERSION', '0.2.1' );
 define( 'WPGRAPHQL_CONTENT_BLOCKS_AUTOLOAD', true );
 define( 'WPGRAPHQL_CONTENT_BLOCKS_PLUGIN_FILE', 'wp-graphql-content-blocks.php' );


### PR DESCRIPTION
## What

This PR

- Stubs `WP_Post_Type` so the custom GraphQL properties are available in PHPStan (and our IDEs)
- Includes `wp-graphql-content-blocks.php` in PHPStan's bootstrapper, to correctly identify the defined constants.

The PHPStan baseline has been updated accordingly.

## Why

Address false positives and uncover more _actual_ tech debt. 