### PR TITLE
fix: `get_allowed_block_types()` can return `bool`

### DIFF
--- a/.changeset/neat-ties-prove.md
+++ b/.changeset/neat-ties-prove.md
@@ -1,0 +1,5 @@
+---
+"@wpengine/wp-graphql-content-blocks": patch
+---
+
+fix: Update parameter type for `$supported_blocks_for_post_type_context` in `wpgraphql_content_blocks_should_apply_post_type_editor_blocks_interfaces` to support boolean values

--- a/includes/Registry/Registry.php
+++ b/includes/Registry/Registry.php
@@ -116,7 +116,7 @@ final class Registry {
 			 * @param \WP_Block_Editor_Context $block_editor_context                   The context of the Block Editor
 			 * @param \WP_Post_Type            $post_type                              The Post Type an Interface might be applied to the block for
 			 * @param array                    $all_registered_blocks                  Array of all registered blocks
-			 * @param array                    $supported_blocks_for_post_type_context Array of all supported blocks for the context
+			 * @param array|bool               $supported_blocks_for_post_type_context Array of all supported blocks for the context
 			 * @param array                    $block_and_graphql_enabled_post_types   Array of Post Types that have block editor and GraphQL support
 			 */
 			$should_apply_post_type_editor_block_interface = apply_filters( 'wpgraphql_content_blocks_should_apply_post_type_editor_blocks_interfaces', true, $block_name, $block_editor_context, $post_type, $all_registered_blocks, $supported_blocks_for_post_type_context, $block_and_graphql_enabled_post_types );

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -36,11 +36,6 @@ parameters:
 			path: includes/Field/BlockSupports/Anchor.php
 
 		-
-			message: "#^@param array \\$supported_blocks_for_post_type_context does not accept actual type of parameter\\: array\\<string\\>\\|bool\\.$#"
-			count: 1
-			path: includes/Registry/Registry.php
-
-		-
 			message: "#^Parameter \\#2 \\$block_spec of static method WPGraphQL\\\\ContentBlocks\\\\Field\\\\BlockSupports\\\\Anchor\\:\\:get_block_attributes_interfaces\\(\\) expects WP_Block_Type, WP_Block_Type\\|null given\\.$#"
 			count: 1
 			path: includes/Registry/Registry.php


### PR DESCRIPTION
## What

This PR changes the param type of `$supported_blocks_for_post_type_context` (used in `wpgraphql_content_blocks_should_apply_post_type_editor_blocks_interfaces` ) to type `array|bool`

> [!WARNING]
> ~This PR requires https://github.com/wpengine/wp-graphql-content-blocks/pull/210 , which should be merged first (to avoid conflicts with the PHPStan baseline). The diff of specific changes is viewable here: b5122b93f10535d4719086edc555a39f1625c21c~

## Why

`get_allow_block_types()` [can return a boolean](https://developer.wordpress.org/reference/functions/get_allowed_block_types/) when all block types are enabled/disabled