### PR TITLE
chore: implement stricter PHPStan ruleset and fix new errors.

### DIFF
--- a/.changeset/wild-hairs-jog.md
+++ b/.changeset/wild-hairs-jog.md
@@ -1,0 +1,5 @@
+---
+"@wpengine/wp-graphql-content-blocks": patch
+---
+
+chore: update PHPStan ruleset for stricter linting, and address newly-discovered tech debt.

--- a/includes/Utilities/DomHelpers.php
+++ b/includes/Utilities/DomHelpers.php
@@ -25,7 +25,7 @@ final class DOMHelpers {
 	 */
 	public static function parseAttribute( $html, $selector, $attribute, $default_value = null ): ?string {
 		$doc = new Document();
-		$doc->loadHTML( $html );
+		$doc->loadHtml( $html );
 		if ( '*' === $selector ) {
 			$selector = '*[' . $attribute . ']';
 		}
@@ -75,7 +75,7 @@ final class DOMHelpers {
 	 */
 	public static function parseHTML( $html, $selector, $default_value = null ) {
 		$doc = new Document();
-		$doc->loadHTML( $html );
+		$doc->loadHtml( $html );
 		$node       = $doc->find( $selector );
 		$inner_html = isset( $default_value ) ? $default_value : '';
 
@@ -95,7 +95,7 @@ final class DOMHelpers {
 	 */
 	public static function getElementsFromHTML( $html, $selector ) {
 		$doc = new Document();
-		$doc->loadHTML( $html );
+		$doc->loadHtml( $html );
 		$elements = $doc->find( $selector );
 
 		$output = '';
@@ -118,7 +118,7 @@ final class DOMHelpers {
 	 */
 	public static function parseText( $html, $selector ) {
 		$doc = new Document();
-		$doc->loadHTML( $html );
+		$doc->loadHtml( $html );
 		$nodes = $doc->find( $selector );
 
 		if ( count( $nodes ) === 0 ) {

--- a/includes/Utilities/DomHelpers.php
+++ b/includes/Utilities/DomHelpers.php
@@ -71,7 +71,7 @@ final class DOMHelpers {
 	 * @param string $selector The selector to use.
 	 * @param mixed  $default_value The default value to return if the selector is not found.
 	 *
-	 * @return string|null extracted innerHTML of selector
+	 * @return string extracted innerHTML of selector
 	 */
 	public static function parseHTML( $html, $selector, $default_value = null ) {
 		$doc = new Document();
@@ -91,7 +91,7 @@ final class DOMHelpers {
 	 * @param string $html The HTML string to parse.
 	 * @param string $selector The element (selector) to extract.
 	 *
-	 * @return string|null the HTML string of the extracted elements
+	 * @return string the HTML string of the extracted elements
 	 */
 	public static function getElementsFromHTML( $html, $selector ) {
 		$doc = new Document();

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -3,7 +3,19 @@ includes:
 parameters:
 		level: 8
 		inferPrivatePropertyTypeFromConstructor: true
-		checkMissingIterableValueType: false
+		checkAlwaysTrueCheckTypeFunctionCall: true
+		checkAlwaysTrueInstanceof: true
+		checkAlwaysTrueStrictComparison: true
+		checkExplicitMixedMissingReturn: true
+		checkFunctionNameCase: true
+		checkInternalClassCaseSensitivity: true
+		checkMissingIterableValueType: false # @todo this should be true
+		checkTooWideReturnTypesInProtectedAndPublicMethods: true
+		polluteScopeWithAlwaysIterableForeach: false
+		polluteScopeWithLoopInitialAssignments: false
+		reportAlwaysTrueInLastCondition: true
+		reportStaticMethodSignatures: true
+		reportWrongPhpDocTypeInVarTag: true
 		treatPhpDocTypesAsCertain: false
 		stubFiles:
 			# Simulate added properties

--- a/phpstan/constants.php
+++ b/phpstan/constants.php
@@ -6,6 +6,5 @@
  */
 
 define( 'WPGRAPHQL_CONTENT_BLOCKS_VERSION', '0.2.1' );
-define( 'WPGRAPHQL_CONTENT_BLOCKS_AUTOLOAD', true );
 define( 'WPGRAPHQL_CONTENT_BLOCKS_PLUGIN_FILE', 'wp-graphql-content-blocks.php' );
 define( 'WPGRAPHQL_CONTENT_BLOCKS_MIN_PHP_VERSION', '7.4' );


### PR DESCRIPTION
## What

This PR updates `phpstan.neon.dist` for stricter detection of errors, and addresses the newly-detected errors. More specifically:
- Calls to `DiDom\Document::loadHtml()` have been updated to use the correct casing. (Previously these were calls to `loadHTML()`)
- Removes `null` from the return DocType of DOMHelpers::getElementsFromHTML() and DOMHelpers::parseHTML(), since those methods only turn a type `string` IRL. Note: The method signature **was not** changed.

> [!WARNING]
> ~This PR requires https://github.com/wpengine/wp-graphql-content-blocks/pull/210 , which should be merged first (to avoid conflicts with the PHPStan baseline). The relevant commits for this PR are:~
> ~- b7109ac14c46552e6e52321084170a5b892ed0d2~
> ~- 4308eafb13bdfe727ec164e876891ae1e28e2f30~
> ~- 52099c213a82f8b33e071d0ffb69e58ebdb76070~