### PR TITLE
fix: Don't register `NodeWithEditorBlocks` interface to `null` type names

### DIFF
--- a/.changeset/unlucky-deers-remain.md
+++ b/.changeset/unlucky-deers-remain.md
@@ -1,0 +1,5 @@
+---
+"@wpengine/wp-graphql-content-blocks": patch
+---
+
+fix: Don't register `NodeWithEditorBlocks` interface to `null` type names.

--- a/includes/Registry/Registry.php
+++ b/includes/Registry/Registry.php
@@ -211,7 +211,12 @@ final class Registry {
 			},
 			$supported_post_types
 		);
+
+		// Remove any null values from the array
+		$type_names = array_filter( $type_names );
+
 		register_graphql_interfaces_to_types( [ 'NodeWithEditorBlocks' ], $type_names );
+
 		$post_id = -1;
 		// For each Post type
 		foreach ( $supported_post_types as $post_type ) {

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -46,11 +46,6 @@ parameters:
 			path: includes/Registry/Registry.php
 
 		-
-			message: "#^Parameter \\#2 \\$type_names of function register_graphql_interfaces_to_types expects array\\<string\\>\\|string, array\\<string\\|null\\> given\\.$#"
-			count: 1
-			path: includes/Registry/Registry.php
-
-		-
 			message: "#^Call to an undefined method DiDom\\\\Element\\|DOMElement\\:\\:html\\(\\)\\.$#"
 			count: 1
 			path: includes/Utilities/DomHelpers.php


### PR DESCRIPTION
## What

This PR filters the supported Post Type graphql names for null values, before attempting to register the `NodeWithEditorBlocks` interface to them.

## Why
`register_graphql_interfaces_to_types()` takes an array of `string` values, not `array<string|null>`.

## Additional notes

> [!IMPORTANT]
> At this stage, we're likely going to start seeing merge conflicts on `phpstan-baseline.neon`, due to multiple lines getting deleted at the source.
>
> To resolve without waiting for @justlevine , restore the base (i.e. `main` branch) `phpstan-baseline.neon` file, and then reapply the removal of the specific allow-listed error from the `phpstan-baseline.neon` diff in this PR.