### PR TITLE
fix: ensure valid `WP_Block_Type` before applying `Anchor` interfaces.

### DIFF
--- a/.changeset/shaggy-walls-rush.md
+++ b/.changeset/shaggy-walls-rush.md
@@ -1,0 +1,5 @@
+---
+"@wpengine/wp-graphql-content-blocks": patch
+---
+
+fix: Ensure valid `WP_Block_Type` before applying `Anchor` interfaces.

--- a/includes/Registry/Registry.php
+++ b/includes/Registry/Registry.php
@@ -170,7 +170,13 @@ final class Registry {
 	 * @return string[]
 	 */
 	public function get_block_additional_interfaces( string $block_name ): array {
-		$block_spec       = $this->block_type_registry->get_registered( $block_name );
+		$block_spec = $this->block_type_registry->get_registered( $block_name );
+
+		// Bail if no block type is found.
+		if ( ! $block_spec instanceof \WP_Block_Type ) {
+			return [];
+		}
+
 		$block_interfaces = [];
 		// NOTE: Using add_filter here creates a performance penalty.
 		$block_interfaces = Anchor::get_block_interfaces( $block_interfaces, $block_spec );
@@ -185,7 +191,13 @@ final class Registry {
 	 * @return string[]
 	 */
 	public function get_block_attributes_interfaces( string $block_name ): array {
-		$block_spec       = $this->block_type_registry->get_registered( $block_name );
+		$block_spec = $this->block_type_registry->get_registered( $block_name );
+
+		// Bail if no block type is found.
+		if ( ! $block_spec instanceof \WP_Block_Type ) {
+			return [];
+		}
+
 		$block_interfaces = [];
 		// NOTE: Using add_filter here creates a performance penalty.
 		$block_interfaces = Anchor::get_block_attributes_interfaces( $block_interfaces, $block_spec );

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -31,16 +31,6 @@ parameters:
 			path: includes/Blocks/Block.php
 
 		-
-			message: "#^Parameter \\#2 \\$block_spec of static method WPGraphQL\\\\ContentBlocks\\\\Field\\\\BlockSupports\\\\Anchor\\:\\:get_block_attributes_interfaces\\(\\) expects WP_Block_Type, WP_Block_Type\\|null given\\.$#"
-			count: 1
-			path: includes/Registry/Registry.php
-
-		-
-			message: "#^Parameter \\#2 \\$block_spec of static method WPGraphQL\\\\ContentBlocks\\\\Field\\\\BlockSupports\\\\Anchor\\:\\:get_block_interfaces\\(\\) expects WP_Block_Type, WP_Block_Type\\|null given\\.$#"
-			count: 1
-			path: includes/Registry/Registry.php
-
-		-
 			message: "#^Call to an undefined method DiDom\\\\Element\\|DOMElement\\:\\:html\\(\\)\\.$#"
 			count: 1
 			path: includes/Utilities/DomHelpers.php


### PR DESCRIPTION
## What

This PR fixes the calls to in `Registry::get_block_additional_interfaces()` and `Registry::get_block_attributes_interfaces()` to ensure that the `$block_spec` is a valid `WP_Block_Type` before trying to apply an `Anchor` interface to it.

## Why

Both `Anchor::get_block_attributes_interfaces()` and `Anchor::get_block_interfaces()` require `$block_spec` to be a valid `WP_Block_Type`.

While the pattern for applying the Anchor Interfaces could be improved, that's beyond the scope of this PR.

## Additional notes

> [!IMPORTANT]
> At this stage, we're likely going to start seeing merge conflicts on `phpstan-baseline.neon`, due to multiple lines getting deleted at the source.
>
> To resolve without waiting for @justlevine , restore the base (i.e. `main` branch) `phpstan-baseline.neon` file, and then reapply the removal of the specific allow-listed error from the `phpstan-baseline.neon` diff in this PR.