### PR TITLE
chore: remove unnecessary `isset()` in `Anchor::get_block_interfaces()`

### DIFF
--- a/.changeset/selfish-rockets-allow.md
+++ b/.changeset/selfish-rockets-allow.md
@@ -1,0 +1,5 @@
+---
+"@wpengine/wp-graphql-content-blocks": patch
+---
+
+chore: remove unnecessary `isset()` in Anchor::get_block_interfaces().

--- a/includes/Field/BlockSupports/Anchor.php
+++ b/includes/Field/BlockSupports/Anchor.php
@@ -48,9 +48,10 @@ class Anchor {
 	 * @return string[]
 	 */
 	public static function get_block_interfaces( $existing, \WP_Block_Type $block_spec ): array {
-		if ( isset( $block_spec ) && isset( $block_spec->supports['anchor'] ) && true === $block_spec->supports['anchor'] ) {
+		if ( isset( $block_spec->supports['anchor'] ) && true === $block_spec->supports['anchor'] ) {
 			$existing[] = 'BlockWithSupportsAnchor';
 		}
+
 		return $existing;
 	}
 

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -31,11 +31,6 @@ parameters:
 			path: includes/Blocks/Block.php
 
 		-
-			message: "#^Variable \\$block_spec in isset\\(\\) always exists and is not nullable\\.$#"
-			count: 1
-			path: includes/Field/BlockSupports/Anchor.php
-
-		-
 			message: "#^Parameter \\#2 \\$block_spec of static method WPGraphQL\\\\ContentBlocks\\\\Field\\\\BlockSupports\\\\Anchor\\:\\:get_block_attributes_interfaces\\(\\) expects WP_Block_Type, WP_Block_Type\\|null given\\.$#"
 			count: 1
 			path: includes/Registry/Registry.php


### PR DESCRIPTION
## What

This PR removes the unnecessary `isset( $block_spec )` check from the guard in `Anchor::get_block_interfaces()`

## Why

`$block_spec` is strictly-typed to `WP_Block_Type`, and therefore `isset()` will always be true.

## Additional notes

> [!IMPORTANT]
> At this stage, we're likely going to start seeing merge conflicts on `phpstan-baseline.neon`, due to multiple lines getting deleted at the source.
>
> To resolve without waiting for @justlevine , restore the base (i.e. `main` branch) `phpstan-baseline.neon` file, and then reapply the removal of the specific allow-listed error from the `phpstan-baseline.neon` diff in this PR.