### PR TITLE
fix: make `get_block_attribute_fields()` `$prefix` param non-nullable

### DIFF
--- a/.changeset/great-pans-poke.md
+++ b/.changeset/great-pans-poke.md
@@ -1,0 +1,5 @@
+---
+"@wpengine/wp-graphql-content-blocks": patch
+---
+
+fix: Change Block:get_block_attribute_fields()`$prefix parameter be an optional`string`.

--- a/includes/Blocks/Block.php
+++ b/includes/Blocks/Block.php
@@ -185,10 +185,10 @@ class Block {
 	/**
 	 * Gets the WPGraphQL field registration config for the block attributes.
 	 *
-	 * @param ?array      $block_attributes The block attributes.
-	 * @param string|null $prefix The current prefix string to use for the get_query_type
+	 * @param ?array $block_attributes The block attributes.
+	 * @param string $prefix The current prefix string to use for the get_query_type
 	 */
-	private function get_block_attribute_fields( ?array $block_attributes, $prefix = '' ): array {
+	private function get_block_attribute_fields( ?array $block_attributes, string $prefix = '' ): array {
 		$fields = [];
 
 		// Bail early if no attributes are defined.

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -26,11 +26,6 @@ parameters:
 			path: includes/Blocks/Block.php
 
 		-
-			message: "#^Parameter \\#3 \\$prefix of method WPGraphQL\\\\ContentBlocks\\\\Blocks\\\\Block\\:\\:get_attribute_type\\(\\) expects string, string\\|null given\\.$#"
-			count: 1
-			path: includes/Blocks/Block.php
-
-		-
 			message: "#^Variable \\$block_spec in isset\\(\\) always exists and is not nullable\\.$#"
 			count: 1
 			path: includes/Field/BlockSupports/Anchor.php


### PR DESCRIPTION
## What

This PR changes the `$prefix` parameter on `Blocks::get_block_attribute_fields()` from a nullable string (`string|null`) to a non-nullable `string`. The parameter remains optional and defaults to `''`.

>[!NOTE]
> This is _not_ considered a breaking change as `get_block_attribute_fields()` is a `private` class method, and [its only usage](https://github.com/justlevine/wp-graphql-content-blocks/blob/55fc5dc82a4bcaa4d4b8d78c286ca2306f66742d/includes/Blocks/Block.php#L90) has it passed a `string` value.

## Why

`Blocks::get_block_attribute_fields()` passes the `$prefix` param to `Blocks::get_attribute_type()` which requires the param to be a non-nullable string.

## Additional notes

> [!IMPORTANT]
> At this stage, we're likely going to start seeing merge conflicts on `phpstan-baseline.neon`, due to multiple lines getting deleted at the source.
>
> To resolve without waiting for @justlevine , restore the base (i.e. `main` branch) `phpstan-baseline.neon` file, and then reapply the removal of the specific allow-listed error from the `phpstan-baseline.neon` diff in this PR.