### PR TITLE
fix: handle arrays before casting when normalizing attribute values

### DIFF
--- a/.changeset/good-poems-battle.md
+++ b/.changeset/good-poems-battle.md
@@ -1,0 +1,5 @@
+---
+"@wpengine/wp-graphql-content-blocks": patch
+---
+
+fix: handle arrays before casting when using `Block::normalize_attribute_value()`

--- a/includes/Blocks/Block.php
+++ b/includes/Blocks/Block.php
@@ -292,10 +292,18 @@ class Block {
 	 * @param array|string $value The value
 	 * @param string       $type The type of the value
 	 * 
-	 * @return mixed
+	 * @return array|string|int|float|bool
 	 */
 	private function normalize_attribute_value( $value, $type ) {
+		// @todo use the `source` to normalize array/object values.
+		if ( is_array( $value ) ) {
+			return $value;
+		}
+
 		switch ( $type ) {
+			case 'array':
+				// If we're here, we want an array type, even though the value is not an array.
+				return isset( $value ) ? [ $value ] : [];
 			case 'string':
 				return (string) $value;
 			case 'number':

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -16,11 +16,6 @@ parameters:
 			path: includes/Blocks/Block.php
 
 		-
-			message: "#^Cannot cast array\\|string to string\\.$#"
-			count: 1
-			path: includes/Blocks/Block.php
-
-		-
 			message: "#^Method WPGraphQL\\\\ContentBlocks\\\\Blocks\\\\Block\\:\\:resolve\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: includes/Blocks/Block.php


### PR DESCRIPTION
## What
This PR fixes the logic inside `Block::normalize_attribute_values()` to:
- return `array` values before casting to the normalized `type`.
- cast strings to an array if the `$type` is an array, but the `$value` is not.

**No effort has been made** to determine the possible Scalar types that `$value` can accept, and instead is assumed to only be a `string|array` as currently defined in the doc-block.

## Why

You can't cast arrays to strings in PHP.

## Additional notes

> [!IMPORTANT]
> At this stage, we're likely going to start seeing merge conflicts on `phpstan-baseline.neon`, due to multiple lines getting deleted at the source.
>
> To resolve without waiting for @justlevine , restore the base (i.e. `main` branch) `phpstan-baseline.neon` file, and then reapply the removal of the specific allow-listed error from the `phpstan-baseline.neon` diff in this PR.