### PR TITLE
dev: inline and remove `Block::resolve()` and make `name` field nullable

### DIFF
--- a/.changeset/serious-numbers-chew.md
+++ b/.changeset/serious-numbers-chew.md
@@ -1,0 +1,5 @@
+---
+"@wpengine/wp-graphql-content-blocks": patch
+---
+
+dev: inline and remove `Block::resolve()` and make `name` field nullable.

--- a/includes/Blocks/Block.php
+++ b/includes/Blocks/Block.php
@@ -344,22 +344,13 @@ class Block {
 					'name' => [
 						'type'        => 'String',
 						'description' => __( 'The name of the block', 'wp-graphql-content-blocks' ),
-						'resolve'     => function ( $block ) {
-							return $this->resolve( $block );
+						'resolve'     => static function ( $block ) {
+							return isset( $block['blockName'] ) ? (string) $block['blockName'] : null;
 						},
 					],
 				],
 			]
 		);
-	}
-
-	/**
-	 * Returns the necessary block data to resolve the block field.
-	 *
-	 * @param mixed $block The block data passed to the resolver.
-	 */
-	private function resolve( $block ) {
-		return isset( $block['blockName'] ) ? $block['blockName'] : '';
 	}
 
 	/**

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -21,11 +21,6 @@ parameters:
 			path: includes/Blocks/Block.php
 
 		-
-			message: "#^Method WPGraphQL\\\\ContentBlocks\\\\Blocks\\\\Block\\:\\:resolve\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: includes/Blocks/Block.php
-
-		-
 			message: "#^Parameter \\#3 \\$prefix of method WPGraphQL\\\\ContentBlocks\\\\Blocks\\\\Block\\:\\:get_attribute_type\\(\\) expects string, string\\|null given\\.$#"
 			count: 1
 			path: includes/Blocks/Block.php


### PR DESCRIPTION
## What
This PR:
- removes the `Block::resolve()` method, and instead inlines the `name` field resolver logic in `register_graphql_object_type()` $config.
- changes the `name` field resolver logic to return `null` if `$source['blockName']` is unset, instead of an empty string.

As the method is private, and the schema for the `name` field already being nullable, this is _not_ a breaking change.

## Why
Prompted by the lack of return type on `Block::resolve()`, I noted it's a private method (i.e. not overloadable by child classes), used only inside another private method `Block::register_type()`.  Removing the type both cleans up the tech debt, and makes it clearer to see what changes would be necessary to actually make `Block` and overloadable class.

## Additional notes

> [!IMPORTANT]
> At this stage, we're likely going to start seeing merge conflicts on `phpstan-baseline.neon`, due to multiple lines getting deleted at the source.
>
> To resolve without waiting for @justlevine , restore the base (i.e. `main` branch) `phpstan-baseline.neon` file, and then reapply the removal of the specific allow-listed error from the `phpstan-baseline.neon` diff in this PR.