### PR TITLE
feat: Block object attributes may have custom types with subfields

### DIFF
--- a/.changeset/eight-steaks-yawn.md
+++ b/.changeset/eight-steaks-yawn.md
@@ -1,0 +1,5 @@
+---
+"@wpengine/wp-graphql-content-blocks": major
+---
+
+feat: Block object attributes may have custom types with subfields

--- a/includes/Blocks/Block.php
+++ b/includes/Blocks/Block.php
@@ -164,7 +164,11 @@ class Block {
 					}
 					break;
 				case 'object':
-					$type = Scalar::get_block_attributes_object_type_name();
+                    if ( isset( $attribute['properties'] ) ) {
+                        $type = $this->get_query_type( $name, $attribute['properties'], $prefix );
+                    } else {
+                        $type = Scalar::get_block_attributes_object_type_name();
+                    }
 					break;
 			}
 		} elseif ( isset( $attribute['source'] ) ) {


### PR DESCRIPTION
If a block attribute has a "properties" key, the attribute now has a custom type with typed subfields.

Fixes #222

Obviously a big concern here is that, to my knowledge, WP haven't documented how object attribute properties should be documented in block.json. "properties" was chosen by convention in JSONSchema.