### PR TITLE
fix: rename `DomHelpers.php` to `DOMHelpers.php` and improve type-safety of internal methods.

### DIFF
--- a/.changeset/tame-baboons-juggle.md
+++ b/.changeset/tame-baboons-juggle.md
@@ -1,0 +1,5 @@
+---
+"@wpengine/wp-graphql-content-blocks": patch
+---
+
+fix: rename `DomHelpers.php` to `DOMHelpers.php` and improve type-safety of internal methods.

--- a/includes/Blocks/Block.php
+++ b/includes/Blocks/Block.php
@@ -394,8 +394,15 @@ class Block {
 					$result[ $key ] = DOMHelpers::parseText( $html, $value['selector'] );
 					break;
 				case 'query':
-					$temp = [];
-					foreach ( DOMHelpers::findNodes( $html, $value['selector'] ) as $source_node ) {
+					$temp  = [];
+					$nodes = DOMHelpers::findNodes( $html, $value['selector'] );
+
+					// Coerce nodes to an array if it's not already.
+					if ( ! is_array( $nodes ) ) {
+						$nodes = [ $nodes ];
+					}
+	
+					foreach ( $nodes as $source_node ) {
 						foreach ( $value['query'] as $q_key => $q_value ) {
 							$temp_config    = [
 								$q_key => $q_value,

--- a/includes/Utilities/DOMHelpers.php
+++ b/includes/Utilities/DOMHelpers.php
@@ -76,12 +76,15 @@ final class DOMHelpers {
 	public static function parseHTML( $html, $selector, $default_value = null ) {
 		$doc = new Document();
 		$doc->loadHtml( $html );
+
+		/** @var \DiDom\Element[] $node */
 		$node       = $doc->find( $selector );
 		$inner_html = isset( $default_value ) ? $default_value : '';
 
 		foreach ( $node as $elem ) {
-			$inner_html .= $elem->innerHTML();
+			$inner_html .= $elem->innerHtml();
 		}
+
 		return $inner_html;
 	}
 
@@ -96,6 +99,8 @@ final class DOMHelpers {
 	public static function getElementsFromHTML( $html, $selector ) {
 		$doc = new Document();
 		$doc->loadHtml( $html );
+
+		/** @var \DiDom\Element[] $elements */
 		$elements = $doc->find( $selector );
 
 		$output = '';
@@ -114,11 +119,13 @@ final class DOMHelpers {
 	 * @param string $html The HTML string to parse.
 	 * @param string $selector The selector to get the text content from.
 	 *
-	 * @return string|null The text content of the selector if found.
+	 * @return ?string The text content of the selector if found.
 	 */
 	public static function parseText( $html, $selector ) {
 		$doc = new Document();
 		$doc->loadHtml( $html );
+
+		/** @var \DiDom\Element[] $nodes */
 		$nodes = $doc->find( $selector );
 
 		if ( count( $nodes ) === 0 ) {
@@ -136,19 +143,26 @@ final class DOMHelpers {
 	 * @param string      $html The HTML string to parse.
 	 * @param string|null $selector The selector to use.
 	 *
-	 * @return \DOMElement[]|\DOMElement
+	 * @return \DiDom\Element[]|\DiDom\Element
 	 */
 	public static function findNodes( $html, $selector = null ) {
 		// Bail early if there's no html to parse.
 		if ( empty( trim( $html ) ) ) {
-			return null;
+			return [];
 		}
+
 		$doc = new Document( $html );
 		// <html><body>$html</body></html>
-		$elem = $doc->find( '*' )[2];
+
+		/** @var \DiDom\Element[] $elements */
+		$elements = $doc->find( '*' );
+		$elem     = $elements[2] ?? [];
+
 		if ( $selector ) {
+			/** @var \DiDom\Element[] $elem */
 			$elem = $doc->find( $selector );
 		}
+
 		return $elem;
 	}
 }

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,17 +1,7 @@
 parameters:
 	ignoreErrors:
 		-
-			message: "#^Argument of an invalid type array\\<DOMElement\\>\\|DOMElement supplied for foreach, only iterables are supported\\.$#"
-			count: 1
-			path: includes/Blocks/Block.php
-
-		-
-			message: "#^Call to an undefined method DOMElement\\:\\:html\\(\\)\\.$#"
-			count: 1
-			path: includes/Blocks/Block.php
-
-		-
-			message: "#^Cannot call method innerHTML\\(\\) on array\\<DOMElement\\>\\|DOMElement\\.$#"
+			message: "#^Cannot call method innerHTML\\(\\) on array\\<DiDom\\\\Element\\>\\|DiDom\\\\Element\\.$#"
 			count: 1
 			path: includes/Blocks/Block.php
 
@@ -44,31 +34,6 @@ parameters:
 			message: "#^Parameter \\#2 \\$block_spec of static method WPGraphQL\\\\ContentBlocks\\\\Field\\\\BlockSupports\\\\Anchor\\:\\:get_block_interfaces\\(\\) expects WP_Block_Type, WP_Block_Type\\|null given\\.$#"
 			count: 1
 			path: includes/Registry/Registry.php
-
-		-
-			message: "#^Call to an undefined method DiDom\\\\Element\\|DOMElement\\:\\:html\\(\\)\\.$#"
-			count: 1
-			path: includes/Utilities/DomHelpers.php
-
-		-
-			message: "#^Call to an undefined method DiDom\\\\Element\\|DOMElement\\:\\:innerHTML\\(\\)\\.$#"
-			count: 1
-			path: includes/Utilities/DomHelpers.php
-
-		-
-			message: "#^Call to an undefined method DiDom\\\\Element\\|DOMElement\\:\\:text\\(\\)\\.$#"
-			count: 1
-			path: includes/Utilities/DomHelpers.php
-
-		-
-			message: "#^Method WPGraphQL\\\\ContentBlocks\\\\Utilities\\\\DOMHelpers\\:\\:findNodes\\(\\) should return array\\<DOMElement\\>\\|DOMElement but returns array\\<DiDom\\\\Element\\|DOMElement\\>\\|DiDom\\\\Element\\|DOMElement\\.$#"
-			count: 1
-			path: includes/Utilities/DomHelpers.php
-
-		-
-			message: "#^Method WPGraphQL\\\\ContentBlocks\\\\Utilities\\\\DOMHelpers\\:\\:findNodes\\(\\) should return array\\<DOMElement\\>\\|DOMElement but returns null\\.$#"
-			count: 1
-			path: includes/Utilities/DomHelpers.php
 
 		-
 			message: "#^Constant WPGRAPHQL_CONTENT_BLOCKS_PLUGIN_DIR not found\\.$#"


### PR DESCRIPTION
## What

This PR renames the `DomHelpers.php` file to `DOMHelpers.php` to match the class-name casing, per PSR-4.

Additionally, it fixes the internal and return types for the DomHelpers methods, and their usage.

## Why

`DiDom` methods have the ability to return either a `DiDom\Element` or a `DOMElement` instance depending on the supplied parameters. By explicitly typing those instances, we're able to unearth actual issues with the methods (like DOMHelpers::findNodes() returning `null` or being used as an array when it returns a single element.

## Additional notes

- The use of `DOMHelpers::findNodes()` in [Block::parse_single_source()](https://github.com/justlevine/wp-graphql-content-blocks/blob/e70bd1f014904eeb39d06134048f9024391b3141/includes/Blocks/Block.php#L457) is _not addressed_ in this PR. We probably want to be using `DOMHelpers::parseHTML()` (to correctly handle a possible array), but I didn't want to include a change I wasnt 100% clear on.

> [!IMPORTANT]
> At this stage, we're likely going to start seeing merge conflicts on `phpstan-baseline.neon`, due to multiple lines getting deleted at the source.
>
> To resolve without waiting for @justlevine , restore the base (i.e. `main` branch) `phpstan-baseline.neon` file, and then reapply the removal of the specific allow-listed error from the `phpstan-baseline.neon` diff in this PR.neon` diff in this PR.