### PR TITLE
chore: add WordPress 6.4 and 6.5 to testing matrix

### DIFF
--- a/.github/workflows/test-plugin.yml
+++ b/.github/workflows/test-plugin.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         php: [ '8.2', '7.4' ]
-        wordpress: [ '6.3', '6.2', '6.1' ]
+        wordpress: [ '6.5', '6.4', '6.3', '6.2', '6.1' ]
         exclude:
         - php: 8.2
           wordpress: 6.1
@@ -20,6 +20,10 @@ jobs:
           wordpress: 6.2
         - php: 7.4
           wordpress: 6.3
+        - php: 7.4
+          wordpress: 6.4
+        - php: 7.4
+          wordpress: 6.5
       fail-fast: false
     name: WordPress ${{ matrix.wordpress }}, PHP ${{ matrix.php }}
     steps:


### PR DESCRIPTION
Adds WordPress 6.4 and 6.5 to the testing matrix.

Note the "draft" status of this PR will be removed upon release of the official WordPress 6.5 Docker image.