### PR TITLE
Breaking Update: Handle `rich-text` field for WordPress >= v6.5

### DIFF
--- a/.changeset/famous-hats-deliver.md
+++ b/.changeset/famous-hats-deliver.md
@@ -1,0 +1,9 @@
+---
+"@wpengine/wp-graphql-content-blocks": major
+---
+
+MAJOR: Update Schema to reflect latest WordPress 6.5 changes.
+
+- WHAT the breaking change is: Added new `rich-text` type
+- WHY the change was made: WordPress 6.5 replaced some of the attribute types from string to `rich-text` causing breaking changes to the existing block fields.
+- HOW a consumer should update their code: If users need to use WordPress >= 6.5 they need to update this plugin to the latest version and update their graphql schemas.

--- a/includes/Blocks/Block.php
+++ b/includes/Blocks/Block.php
@@ -136,9 +136,7 @@ class Block {
 
 		if ( isset( $attribute['type'] ) ) {
 			switch ( $attribute['type'] ) {
-				case 'rich-text': 
-					$type = 'String';
-					break;
+				case 'rich-text':
 				case 'string':
 					$type = 'String';
 					break;
@@ -300,7 +298,6 @@ class Block {
 	private function normalize_attribute_value( $value, $type ) {
 		switch ( $type ) {
 			case 'rich-text':
-				return (string) $value;
 			case 'string':
 				return (string) $value;
 			case 'number':

--- a/includes/Blocks/Block.php
+++ b/includes/Blocks/Block.php
@@ -136,6 +136,8 @@ class Block {
 
 		if ( isset( $attribute['type'] ) ) {
 			switch ( $attribute['type'] ) {
+				case 'rich-text': 
+					$type = 'String';
 				case 'string':
 					$type = 'String';
 					break;
@@ -296,6 +298,8 @@ class Block {
 	 */
 	private function normalize_attribute_value( $value, $type ) {
 		switch ( $type ) {
+			case 'rich-text':
+				return (string) $value;
 			case 'string':
 				return (string) $value;
 			case 'number':
@@ -367,6 +371,7 @@ class Block {
 			$default = $value['default'] ?? null;
 			$source  = $value['source'] ?? null;
 			switch ( $source ) {
+				case 'rich-text':
 				case 'html':
 					if ( ! isset( $value['selector'] ) ) {
 						$result[ $key ] = $this->parse_single_source( $html, $source );

--- a/includes/Blocks/Block.php
+++ b/includes/Blocks/Block.php
@@ -138,6 +138,7 @@ class Block {
 			switch ( $attribute['type'] ) {
 				case 'rich-text': 
 					$type = 'String';
+					break;
 				case 'string':
 					$type = 'String';
 					break;

--- a/includes/Blocks/CoreCode.php
+++ b/includes/Blocks/CoreCode.php
@@ -23,11 +23,5 @@ class CoreCode extends Block {
 			'source'    => 'attribute',
 			'attribute' => 'class',
 		],
-		'content'      => [
-			'type'     => 'string',
-			'selector' => 'code',
-			'source'   => 'html',
-			'default'  => '',
-		],
 	];
 }

--- a/includes/Blocks/CoreParagraph.php
+++ b/includes/Blocks/CoreParagraph.php
@@ -23,11 +23,5 @@ class CoreParagraph extends Block {
 			'source'    => 'attribute',
 			'attribute' => 'class',
 		],
-		'content'      => [
-			'type'     => 'string',
-			'selector' => 'p',
-			'source'   => 'html',
-			'default'  => '',
-		],
 	];
 }


### PR DESCRIPTION
# Description
MAJOR: Update Schema to reflect latest WordPress 6.5 changes.

- **WHAT the breaking change is:** Added a new `rich-text` type.
- **WHY the change was made:** WordPress 6.5 replaced some of the attribute types from string to `rich-text` causing breaking changes to the existing block fields.
- **HOW a consumer should update their code:** If users need to use WordPress >= 6.5 they need to update this plugin to the latest version and update their graphql schemas.


# Related
https://github.com/wpengine/wp-graphql-content-blocks/issues/225

# Testing

-Update to WordPress 6.5
- Add a post with some paragraphs, code and heading blocks
- When querying their `content` attributes, there should be no issues or graphql errors.
