### PR TITLE
Use "release" trigger for running the upload schema workflow.

### DIFF
--- a/.github/workflows/upload-schema-artifact.yml
+++ b/.github/workflows/upload-schema-artifact.yml
@@ -1,9 +1,8 @@
 name: Upload Schema Artifact
 
 on:
-  push:
-    tags:
-      - "*"
+  release:
+    types: [ published ]
 
 jobs:
   run:


### PR DESCRIPTION
This abandons the tag push which, upon research, isn't triggered due to how the release action tags the release itself.

Instead of relying on the tag, it moves to the `release` trigger in an attempt to run when a release is published.

In testing on a personal repo the trigger is fired successfully. A test here won't be possible until we try a fresh release.