### PR TITLE
ci: add PHPStan workflow

### DIFF
--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -1,0 +1,24 @@
+name: PHPStan Static Analysis
+
+on:
+  pull_request:
+    paths-ignore:
+      - '**/*.md'
+
+jobs:
+  phpstan:
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.2'
+
+      - name: Install Dependencies
+        run: composer install
+
+      - name: Run PHPStan
+        run: composer phpstan

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
     "lint": "parallel-lint -e php --no-colors --exclude vendor .",
     "phpcs": "phpcs",
     "phpcs:fix": "phpcbf",
-    "phpstan": "phpstan analyze --ansi --memory-limit=1G",
+    "phpstan": "phpstan analyze --ansi --memory-limit=1G -v",
     "suite": [
         "@lint",
         "@phpcs",


### PR DESCRIPTION
## What

This PR runs PHPStan as part of the CI workflow on pull requests.

## Why

Prevent regressions in static analysis.