### PR TITLE
fix: undefined array keys in `Block::resolve_block_attributes_recursive()`

### DIFF
--- a/.changeset/weak-knives-brush.md
+++ b/.changeset/weak-knives-brush.md
@@ -1,0 +1,5 @@
+---
+"@wpengine/wp-graphql-content-blocks": patch
+---
+
+fix: refactor `Block::resolve_block_attributes_recursive()` and improve type safety


### PR DESCRIPTION
## What

This PR refactors `Block::resolve_block_attributes_recursive()` in the following ways:

1. Add types to the method signature _when the types are certain_.
2. Breaks out source parsing into individual methods, for reduced code complexity.
3. Checks for array keys before they are used on the array:
- On required `$value` keys that are necessary to parse the source.
- Before post-processing the `$return[ $key ]` values retrieved from the source.

## Why
Prevents `Undefined array key` PHP warnings, as well as improves handling of malformed blocks.

Fixes #238 