### PR TITLE
fix: dont overload `NodeWithEditorBlocks.flat`

### DIFF
--- a/.changeset/wild-seas-buy.md
+++ b/.changeset/wild-seas-buy.md
@@ -1,0 +1,5 @@
+---
+"@wpengine/wp-graphql-content-blocks": patch
+---
+
+fix: Don't overload `NodeWithEditorBlocks.flat` on implementing Interfaces.

--- a/includes/Type/InterfaceType/PostTypeBlockInterface.php
+++ b/includes/Type/InterfaceType/PostTypeBlockInterface.php
@@ -62,11 +62,6 @@ final class PostTypeBlockInterface {
 						'type'        => [
 							'list_of' => ucfirst( $post_type ) . 'EditorBlock',
 						],
-						'args'        => [
-							'flat' => [
-								'type' => 'Boolean',
-							],
-						],
 						'description' => sprintf(
 							// translators: %s is the post type.
 							__( 'List of %s editor blocks', 'wp-graphql-content-blocks' ),


### PR DESCRIPTION
## What

This PR removes the unnecessary `flat` arg definition from `NodeWith{$Post_Type}EditorBlocks`, instead relying on the arg definition set by the parent `NodeWithEditorBlocks`.

## Why
The _real_ reason is that there is no difference between the parent and child implementations, so there's no reason to overload.

The superficial reason is that it works around a WPGraphQL core regression https://github.com/wp-graphql/wp-graphql/pull/3152 which:
- closes #240 
- fixes the missing argument description error in `graphql-schema-linter`.

## Screenshots
Look ma no `extension.debug` messages
![image](https://github.com/wpengine/wp-graphql-content-blocks/assets/29322304/321fc1a2-9158-4f37-a304-373279ad4967)
