### PR TITLE
ci: replace `docker-compose` commands with `docker compose`

### DIFF
--- a/.changeset/green-baboons-double.md
+++ b/.changeset/green-baboons-double.md
@@ -1,0 +1,5 @@
+---
+"@wpengine/wp-graphql-content-blocks": patch
+---
+
+ci: replace `docker-compose` commands with `docker compose`

--- a/.github/workflows/test-plugin-nightly.yml
+++ b/.github/workflows/test-plugin-nightly.yml
@@ -19,10 +19,10 @@ jobs:
           WP_VERSION: 6.5
         working-directory: ./
         run: |
-          docker-compose build \
+          docker compose build \
             --build-arg WP_VERSION=6.5 \
             --build-arg PHP_VERSION=8.2
-          docker-compose up -d
+          docker compose up -d
 
       - name: Wait for db
         run: |
@@ -32,22 +32,22 @@ jobs:
 
       - name: Setup testing framework
         working-directory: ./
-        run: docker exec -e COVERAGE=1 $(docker-compose ps -q wordpress) init-testing-environment.sh
+        run: docker exec -e COVERAGE=1 $(docker compose ps -q wordpress) init-testing-environment.sh
 
       - name: Ensure Correct WordPress version
         run: |
-          docker exec --workdir=/var/www/html/wp-content/plugins/wp-graphql-content-blocks $(docker-compose ps -q wordpress) wp core version --allow-root
-          docker exec --workdir=/var/www/html/wp-content/plugins/wp-graphql-content-blocks $(docker-compose ps -q wordpress) wp core upgrade --version=nightly --force --allow-root
-          docker exec --workdir=/var/www/html/wp-content/plugins/wp-graphql-content-blocks $(docker-compose ps -q wordpress) wp core version --allow-root
+          docker exec --workdir=/var/www/html/wp-content/plugins/wp-graphql-content-blocks $(docker compose ps -q wordpress) wp core version --allow-root
+          docker exec --workdir=/var/www/html/wp-content/plugins/wp-graphql-content-blocks $(docker compose ps -q wordpress) wp core upgrade --version=nightly --force --allow-root
+          docker exec --workdir=/var/www/html/wp-content/plugins/wp-graphql-content-blocks $(docker compose ps -q wordpress) wp core version --allow-root
 
       - name: Install and activate WP GraphQL
         working-directory: ./
-        run: docker exec --workdir=/var/www/html/wp-content/plugins/wp-graphql-content-blocks $(docker-compose ps -q wordpress) wp plugin install wp-graphql --activate --allow-root
+        run: docker exec --workdir=/var/www/html/wp-content/plugins/wp-graphql-content-blocks $(docker compose ps -q wordpress) wp plugin install wp-graphql --activate --allow-root
 
       - name: Install Dependencies
         working-directory: ./
-        run: docker exec -e COVERAGE=1 -w /var/www/html/wp-content/plugins/wp-graphql-content-blocks $(docker-compose ps -q wordpress) composer install
+        run: docker exec -e COVERAGE=1 -w /var/www/html/wp-content/plugins/wp-graphql-content-blocks $(docker compose ps -q wordpress) composer install
 
       - name: Run unit tests
         working-directory: ./
-        run: docker exec -e COVERAGE=1 -w /var/www/html/wp-content/plugins/wp-graphql-content-blocks $(docker-compose ps -q wordpress) composer test
+        run: docker exec -e COVERAGE=1 -w /var/www/html/wp-content/plugins/wp-graphql-content-blocks $(docker compose ps -q wordpress) composer test

--- a/.github/workflows/test-plugin.yml
+++ b/.github/workflows/test-plugin.yml
@@ -36,10 +36,10 @@ jobs:
           WP_VERSION: ${{ matrix.wordpress }}
         working-directory: ./
         run: |
-          docker-compose build \
+          docker compose build \
             --build-arg WP_VERSION=${{ matrix.wordpress }} \
             --build-arg PHP_VERSION=${{ matrix.php }}
-          docker-compose up -d
+          docker compose up -d
 
       - name: Wait for db
         run: |
@@ -49,16 +49,16 @@ jobs:
 
       - name: Setup testing framework
         working-directory: ./
-        run: docker exec -e COVERAGE=1 $(docker-compose ps -q wordpress) init-testing-environment.sh
+        run: docker exec -e COVERAGE=1 $(docker compose ps -q wordpress) init-testing-environment.sh
 
       - name: Install and activate WP GraphQL
         working-directory: ./
-        run: docker exec --workdir=/var/www/html/wp-content/plugins/wp-graphql-content-blocks $(docker-compose ps -q wordpress) wp plugin install wp-graphql --activate --allow-root
+        run: docker exec --workdir=/var/www/html/wp-content/plugins/wp-graphql-content-blocks $(docker compose ps -q wordpress) wp plugin install wp-graphql --activate --allow-root
 
       - name: Install Dependencies
         working-directory: ./
-        run: docker exec -e COVERAGE=1 -w /var/www/html/wp-content/plugins/wp-graphql-content-blocks $(docker-compose ps -q wordpress) composer install
+        run: docker exec -e COVERAGE=1 -w /var/www/html/wp-content/plugins/wp-graphql-content-blocks $(docker compose ps -q wordpress) composer install
 
       - name: Run unit tests
         working-directory: ./
-        run: docker exec -e COVERAGE=1 -w /var/www/html/wp-content/plugins/wp-graphql-content-blocks $(docker-compose ps -q wordpress) composer test
+        run: docker exec -e COVERAGE=1 -w /var/www/html/wp-content/plugins/wp-graphql-content-blocks $(docker compose ps -q wordpress) composer test


### PR DESCRIPTION
## What

This PR replaces all instances of the outdated `docker-compose` command with the current syntax: `docker compose`

## Why

Havn't seen an article yet, but seems like GH runners dropped compatibility with the old command: https://github.com/wpengine/wp-graphql-content-blocks/actions/runs/10094219877/job/28273101015?pr=257

