### PR TITLE
docs: Update README badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # WPGraphQL Content Blocks
 
-[![End-to-End Tests](https://github.com/wpengine/wp-graphql-content-blocks/actions/workflows/e2e-tests.yml/badge.svg)](https://github.com/wpengine/wp-graphql-content-blocks/actions/workflows/e2e-tests.yml)
+[![Test Plugin](https://github.com/wpengine/wp-graphql-content-blocks/actions/workflows/test-plugin.yml/badge.svg)](https://github.com/wpengine/wp-graphql-content-blocks/actions/workflows/test-plugin.yml)
 
 [![Download Latest Version](https://img.shields.io/github/package-json/version/wpengine/wp-graphql-content-blocks?label=Download%20Latest%20Version)](https://github.com/wpengine/wp-graphql-content-blocks/releases/latest/download/wp-graphql-content-blocks.zip)
 


### PR DESCRIPTION
These changes update the broken readme badge to point to an existing test

![CleanShot 2024-08-12 at 12 49 16@2x](https://github.com/user-attachments/assets/49d2c5a9-933e-44ce-822c-93759870afda)