### PR TITLE
fix: check if `get_current_screen()` is set before accessing properties

### DIFF
--- a/.changeset/green-cows-accept.md
+++ b/.changeset/green-cows-accept.md
@@ -1,0 +1,5 @@
+---
+"@wpengine/wp-graphql-content-blocks": patch
+---
+
+Fix: prevent fatal errors when get_current_screen() is unset.

--- a/includes/updates/update-callbacks.php
+++ b/includes/updates/update-callbacks.php
@@ -87,7 +87,7 @@ add_action( 'admin_notices', __NAMESPACE__ . '\delegate_plugin_row_notice' );
  */
 function delegate_plugin_row_notice() {
 	$screen = get_current_screen();
-	if ( 'plugins' !== $screen->id ) {
+	if ( ! isset( $screen->id ) || 'plugins' !== $screen->id ) {
 		return;
 	}
 
@@ -139,7 +139,7 @@ add_action( 'admin_notices', __NAMESPACE__ . '\display_update_page_notice' );
  */
 function display_update_page_notice() {
 	$screen = get_current_screen();
-	if ( 'update-core' !== $screen->id ) {
+	if ( ! isset( $screen->id ) || 'update-core' !== $screen->id ) {
 		return;
 	}
 

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -21,11 +21,6 @@ parameters:
 			path: includes/updates/update-callbacks.php
 
 		-
-			message: "#^Cannot access property \\$id on WP_Screen\\|null\\.$#"
-			count: 2
-			path: includes/updates/update-callbacks.php
-
-		-
 			message: "#^Function WPGraphQL\\\\ContentBlocks\\\\PluginUpdater\\\\custom_plugin_api_request\\(\\) has invalid return type WPGraphQL\\\\ContentBlocks\\\\PluginUpdater\\\\stdClass\\.$#"
 			count: 1
 			path: includes/updates/update-callbacks.php


### PR DESCRIPTION
## What

This PR fixes the usage of `get_current_screen()` to check if it's set, before attempting to access properties.

## Why

It can cause a fatal php error. Personally, it's getting in the way of my unit tests.

![image](https://github.com/user-attachments/assets/fd5f7b5a-40e3-4263-aff3-d407809a4b98)


## To test

```php
<?php
// functions.php
  do_action( 'admin_notices' );
```
If it doesnt error, it worked. Or just run `composer phpstan` and confirm it's passing even though the ignore rule has been removed from the baseline.
