### PR TITLE
chore: test against WP 6.6

### DIFF
--- a/.changeset/light-frogs-grow.md
+++ b/.changeset/light-frogs-grow.md
@@ -1,0 +1,5 @@
+---
+"@wpengine/wp-graphql-content-blocks": patch
+---
+
+ci: test against WordPress 6.6

--- a/.github/workflows/test-plugin-nightly.yml
+++ b/.github/workflows/test-plugin-nightly.yml
@@ -16,11 +16,11 @@ jobs:
       - name: Create Docker Containers
         env:
           PHP_VERSION: 8.2
-          WP_VERSION: 6.5
+          WP_VERSION: 6.6
         working-directory: ./
         run: |
           docker compose build \
-            --build-arg WP_VERSION=6.5 \
+            --build-arg WP_VERSION=6.6 \
             --build-arg PHP_VERSION=8.2
           docker compose up -d
 

--- a/.github/workflows/test-plugin.yml
+++ b/.github/workflows/test-plugin.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         php: [ '8.2', '7.4' ]
-        wordpress: [ '6.5', '6.4', '6.3', '6.2', '6.1' ]
+        wordpress: [ '6.6','6.5', '6.4', '6.3', '6.2', '6.1' ]
         exclude:
         - php: 8.2
           wordpress: 6.1
@@ -24,6 +24,8 @@ jobs:
           wordpress: 6.4
         - php: 7.4
           wordpress: 6.5
+        - php: 7.4
+          wordpress: 6.6
       fail-fast: false
     name: WordPress ${{ matrix.wordpress }}, PHP ${{ matrix.php }}
     steps:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.6'
-
 services:
   wordpress:
     build:

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: blakewpe, chriswiegman, joefusco, matthewguywright, TeresaGobble, thdespou, wpengine
 Tags: faustjs, faust, headless, decoupled, gutenberg
 Requires at least: 5.7
-Tested up to: 6.5
+Tested up to: 6.6
 Stable tag: 4.1.0
 Requires PHP: 7.4
 License: GPLv2 or later

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: blakewpe, chriswiegman, joefusco, matthewguywright, TeresaGobble, thdespou, wpengine
 Tags: faustjs, faust, headless, decoupled, gutenberg
 Requires at least: 5.7
-Tested up to: 6.6
+Tested up to: 6.6.2
 Stable tag: 4.1.0
 Requires PHP: 7.4
 License: GPLv2 or later


### PR DESCRIPTION
## What

This PR explicitly tests the plugin against WP 6.6.x and bumps the readme.txt headers to 6.6.2