### PR TITLE
tests: fix PHP deprecated notice - Automatic conversion of false to array

### DIFF
--- a/.changeset/little-cobras-admire.md
+++ b/.changeset/little-cobras-admire.md
@@ -1,0 +1,5 @@
+---
+"@wpengine/wp-graphql-content-blocks": patch
+---
+
+tests: fix PHP deprecation notices

--- a/tests/unit/BlockSupportsAnchorTest.php
+++ b/tests/unit/BlockSupportsAnchorTest.php
@@ -11,10 +11,7 @@ final class BlockSupportsAnchorTest extends PluginTestCase {
 	public function setUp(): void {
 		parent::setUp();
 
-		$settings                                 = get_option( 'graphql_general_settings' );
-		if ( ! is_array( $settings ) ) {
-			$settings = [];
-		}
+		$settings                                 = get_option( 'graphql_general_settings', [] );
 		$settings['public_introspection_enabled'] = 'on';
 		update_option( 'graphql_general_settings', $settings );
 

--- a/tests/unit/BlockSupportsAnchorTest.php
+++ b/tests/unit/BlockSupportsAnchorTest.php
@@ -12,6 +12,9 @@ final class BlockSupportsAnchorTest extends PluginTestCase {
 		parent::setUp();
 
 		$settings                                 = get_option( 'graphql_general_settings' );
+		if ( ! is_array( $settings ) ) {
+			$settings = [];
+		}
 		$settings['public_introspection_enabled'] = 'on';
 		update_option( 'graphql_general_settings', $settings );
 

--- a/tests/unit/EditorBlockInterfaceTest.php
+++ b/tests/unit/EditorBlockInterfaceTest.php
@@ -9,6 +9,9 @@ final class EditorBlockInterfaceTest extends PluginTestCase {
 		parent::setUp();
 
 		$settings                                 = get_option( 'graphql_general_settings' );
+		if ( ! is_array( $settings ) ) {
+			$settings = [];
+		}
 		$settings['public_introspection_enabled'] = 'on';
 		update_option( 'graphql_general_settings', $settings );
 	}

--- a/tests/unit/EditorBlockInterfaceTest.php
+++ b/tests/unit/EditorBlockInterfaceTest.php
@@ -8,10 +8,7 @@ final class EditorBlockInterfaceTest extends PluginTestCase {
 	public function setUp(): void {
 		parent::setUp();
 
-		$settings                                 = get_option( 'graphql_general_settings' );
-		if ( ! is_array( $settings ) ) {
-			$settings = [];
-		}
+		$settings                                 = get_option( 'graphql_general_settings', [] );
 		$settings['public_introspection_enabled'] = 'on';
 		update_option( 'graphql_general_settings', $settings );
 	}

--- a/tests/unit/PostTypeBlockInterfaceTest.php
+++ b/tests/unit/PostTypeBlockInterfaceTest.php
@@ -11,6 +11,9 @@ final class PostTypeBlockInterfaceTest extends PluginTestCase {
 		parent::setUp();
 
 		$settings                                 = get_option( 'graphql_general_settings' );
+		if ( ! is_array( $settings ) ) {
+			$settings = [];
+		}
 		$settings['public_introspection_enabled'] = 'on';
 		update_option( 'graphql_general_settings', $settings );
 

--- a/tests/unit/PostTypeBlockInterfaceTest.php
+++ b/tests/unit/PostTypeBlockInterfaceTest.php
@@ -10,10 +10,7 @@ final class PostTypeBlockInterfaceTest extends PluginTestCase {
 	public function setUp(): void {
 		parent::setUp();
 
-		$settings                                 = get_option( 'graphql_general_settings' );
-		if ( ! is_array( $settings ) ) {
-			$settings = [];
-		}
+		$settings                                 = get_option( 'graphql_general_settings', [] );
 		$settings['public_introspection_enabled'] = 'on';
 		update_option( 'graphql_general_settings', $settings );
 

--- a/tests/unit/RegistryTestCase.php
+++ b/tests/unit/RegistryTestCase.php
@@ -14,6 +14,9 @@ final class RegistryTestCase extends PluginTestCase {
 		parent::setUp();
 
 		$settings                                 = get_option( 'graphql_general_settings' );
+		if ( ! is_array( $settings ) ) {
+			$settings = [];
+		}
 		$settings['public_introspection_enabled'] = 'on';
 		update_option( 'graphql_general_settings', $settings );
 

--- a/tests/unit/RegistryTestCase.php
+++ b/tests/unit/RegistryTestCase.php
@@ -13,10 +13,7 @@ final class RegistryTestCase extends PluginTestCase {
 	public function setUp(): void {
 		parent::setUp();
 
-		$settings                                 = get_option( 'graphql_general_settings' );
-		if ( ! is_array( $settings ) ) {
-			$settings = [];
-		}
+		$settings                                 = get_option( 'graphql_general_settings', [] );
 		$settings['public_introspection_enabled'] = 'on';
 		update_option( 'graphql_general_settings', $settings );
 


### PR DESCRIPTION
## What

This PR fixes deprecation warnings in several PHPUnit tests caused by accessing an undefined `get_option('graphql_general_settings')`.

> [!IMPORTANT]
> This PR is based on https://github.com/wpengine/wp-graphql-content-blocks/pull/280 and requires it to be merged first

## Why
The deprecated warnings were being shown on running the `composer tests`.

## How
- Ensure `$settings` is an array before updating one of it's values.

## Screenshot :

Before :
<img width="1234" alt="Screenshot 2024-09-16 at 7 11 14 PM" src="https://github.com/user-attachments/assets/3031e6ad-e025-402b-a3e6-c6bf477f126c">


No more deprecation warnings ✅ 

<img width="1236" alt="Screenshot 2024-09-16 at 6 40 47 PM" src="https://github.com/user-attachments/assets/ade5786a-007e-4fa6-a004-9a1bcb08f7e8">

