### PR TITLE
feat: expose `EditorBlock.type` field

### DIFF
--- a/.changeset/ten-bulldogs-cover.md
+++ b/.changeset/ten-bulldogs-cover.md
@@ -1,0 +1,5 @@
+---
+"@wpengine/wp-graphql-content-blocks": minor
+---
+
+feat: expose `EditorBlock.type` field

--- a/includes/Type/InterfaceType/EditorBlockInterface.php
+++ b/includes/Type/InterfaceType/EditorBlockInterface.php
@@ -138,15 +138,13 @@ final class EditorBlockInterface {
 							return render_block( $block );
 						},
 					],
+					'type'                    => [
+						'type'        => 'String',
+						'description' => __( 'The (GraphQL) type of the block', 'wp-graphql-content-blocks' ),
+					],
 				],
 				'resolveType'     => static function ( $block ) {
-					if ( empty( $block['blockName'] ) ) {
-						$block['blockName'] = 'core/freeform';
-					}
-
-					$type_name = lcfirst( ucwords( $block['blockName'], '/' ) );
-
-					return WPGraphQLHelpers::format_type_name( $type_name );
+					return WPGraphQLHelpers::get_type_name_for_block( $block['blockName'] ?? null );
 				},
 			]
 		);

--- a/includes/Type/InterfaceType/PostTypeBlockInterface.php
+++ b/includes/Type/InterfaceType/PostTypeBlockInterface.php
@@ -36,13 +36,7 @@ final class PostTypeBlockInterface {
 					],
 				],
 				'resolveType' => static function ( $block ) {
-					if ( empty( $block['blockName'] ) ) {
-						$block['blockName'] = 'core/freeform';
-					}
-
-					$type_name = lcfirst( ucwords( $block['blockName'], '/' ) );
-
-					return WPGraphQLHelpers::format_type_name( $type_name );
+					return WPGraphQLHelpers::get_type_name_for_block( $block['blockName'] ?? null );
 				},
 			]
 		);

--- a/includes/Utilities/WPGraphQLHelpers.php
+++ b/includes/Utilities/WPGraphQLHelpers.php
@@ -32,4 +32,21 @@ final class WPGraphQLHelpers {
 
 		return ! empty( $type_name ) ? Utils::format_type_name( $type_name ) : $type_name;
 	}
+
+	/**
+	 * Gets the GraphQL type name for a provided block name.
+	 *
+	 * @internal This method will likely be removed in the future in favor of a block Model.
+	 *
+	 * @param ?string $block_name The name of the block.
+	 */
+	public static function get_type_name_for_block( ?string $block_name ): string {
+		if ( empty( $block_name ) ) {
+			$block_name = 'core/freeform';
+		}
+
+		$type_name = lcfirst( ucwords( $block_name, '/' ) );
+
+		return self::format_type_name( $type_name );
+	}
 }

--- a/tests/unit/EditorBlockInterfaceTest.php
+++ b/tests/unit/EditorBlockInterfaceTest.php
@@ -97,6 +97,7 @@ final class EditorBlockInterfaceTest extends PluginTestCase {
 			'clientId',
 			'parentClientId',
 			'renderedHtml',
+			'type',
 		];
 		$this->assertArrayHasKey( 'data', $response, json_encode( $response ) );
 		$actual = array_map(

--- a/tests/unit/PostTypeBlockInterfaceTest.php
+++ b/tests/unit/PostTypeBlockInterfaceTest.php
@@ -89,6 +89,7 @@ final class PostTypeBlockInterfaceTest extends PluginTestCase {
 			'clientId',
 			'parentClientId',
 			'renderedHtml',
+			'type',
 		];
 		$this->assertArrayHasKey( 'data', $response, json_encode( $response ) );
 		$actual = array_map(


### PR DESCRIPTION
## What

This PR adds the `type` field to the `EditorBlock` interface.

## Why

Many block implementations (including Faust) rely on using the block type to match the component. Currently, the only way to do that is enable public introspection for the entire GraphQL server, and use `__typename`. By adding a `type` field, we can do that mapping without public introspection.

## How

A new `WPGraphQLHelpers::get_type_name_for_block()` method has been introduced to keep the code DRY. It's been marked `@internal` to discourage usage (since once we have a Block model, we can _just_ define the `type` and use `$block->type` to resolve the interface).

