### PR TITLE
tests: fix `setUp()`/`tearDown()` methods

### DIFF
--- a/.changeset/dull-pandas-joke.md
+++ b/.changeset/dull-pandas-joke.md
@@ -1,0 +1,5 @@
+---
+"@wpengine/wp-graphql-content-blocks": patch
+---
+
+tests: fix `setUp()`/`tearDown()` methods to prevent PHPUnit lifecycle issues.

--- a/tests/unit/AutoloaderTest.php
+++ b/tests/unit/AutoloaderTest.php
@@ -34,14 +34,13 @@ final class AutoloaderTest extends PluginTestCase {
 	}
 
 	public function testRequireAutoloader() {
-		$reflection = new \ReflectionClass( $this->autoloader );
-		$is_loaded_property   = $reflection->getProperty( 'is_loaded' );
+		$reflection         = new \ReflectionClass( $this->autoloader );
+		$is_loaded_property = $reflection->getProperty( 'is_loaded' );
 		$is_loaded_property->setAccessible( true );
 		$is_loaded_property->setValue( $this->autoloader, false );
 
 		$method = $reflection->getMethod( 'require_autoloader' );
 		$method->setAccessible( true );
-
 
 		$this->assertTrue( $method->invokeArgs( $this->autoloader, [ WPGRAPHQL_CONTENT_BLOCKS_PLUGIN_DIR . '/vendor/autoload.php' ] ) );
 

--- a/tests/unit/BlockAttributesObjectTest.php
+++ b/tests/unit/BlockAttributesObjectTest.php
@@ -9,8 +9,6 @@ final class BlockAttributesObjectTest extends PluginTestCase {
 	public function setUp(): void {
 		parent::setUp();
 
-		global $wpdb;
-
 		$this->post_id = wp_insert_post(
 			[
 				'post_title'   => 'Post Title',
@@ -27,13 +25,16 @@ final class BlockAttributesObjectTest extends PluginTestCase {
 				'post_status'  => 'publish',
 			]
 		);
+
+		\WPGraphQL::clear_schema();
 	}
 
 	public function tearDown(): void {
 		// your tear down methods here
-		parent::tearDown();
-
 		wp_delete_post( $this->post_id, true );
+		\WPGraphQL::clear_schema();
+
+		parent::tearDown();
 	}
 
 	public function test_resolve_attribute_object_type() {

--- a/tests/unit/BlockQueriesTest.php
+++ b/tests/unit/BlockQueriesTest.php
@@ -9,8 +9,6 @@ final class BlockQueriesTest extends PluginTestCase {
 	public function setUp(): void {
 		parent::setUp();
 
-		global $wpdb;
-
 		$this->post_id = wp_insert_post(
 			[
 				'post_title'   => 'Post Title',
@@ -38,13 +36,16 @@ final class BlockQueriesTest extends PluginTestCase {
 				'post_status'  => 'publish',
 			]
 		);
+
+		\WPGraphQL::clear_schema();
 	}
 
 	public function tearDown(): void {
 		// your tear down methods here
-		parent::tearDown();
-
 		wp_delete_post( $this->post_id, true );
+		\WPGraphQL::clear_schema();
+
+		parent::tearDown();
 	}
 
 	public function test_retrieve_non_flatten_editor_blocks() {

--- a/tests/unit/BlockSupportsAnchorTest.php
+++ b/tests/unit/BlockSupportsAnchorTest.php
@@ -48,10 +48,11 @@ final class BlockSupportsAnchorTest extends PluginTestCase {
 
 	public function tearDown(): void {
 		// your tear down methods here
-		parent::tearDown();
-
 		wp_delete_post( $this->post_id, true );
+		delete_option( 'graphql_general_settings' );
 		\WPGraphQL::clear_schema();
+
+		parent::tearDown();
 	}
 
 	/**

--- a/tests/unit/ContentBlocksResolverTest.php
+++ b/tests/unit/ContentBlocksResolverTest.php
@@ -83,15 +83,18 @@ final class ContentBlocksResolverTest extends PluginTestCase {
 		);
 
 		$this->instance = new ContentBlocksResolver();
+
+		\WPGraphQL::clear_schema();
 	}
 
 	public function tearDown(): void {
 		// your tear down methods here
-		parent::tearDown();
-
 		wp_delete_post( $this->post_id, true );
 		wp_delete_post( $this->reusable_post_id, true );
 		wp_delete_post( $this->reusable_block_id, true );
+		\WPGraphQL::clear_schema();
+
+		parent::tearDown();
 	}
 
 	public function test_resolve_content_blocks_resolves_reusable_blocks() {

--- a/tests/unit/CoreImageTest.php
+++ b/tests/unit/CoreImageTest.php
@@ -10,7 +10,6 @@ final class CoreImageTest extends PluginTestCase {
 	public function setUp(): void {
 		parent::setUp();
 
-		global $wpdb;
 		$this->attachment_id = $this->factory->attachment->create_upload_object( WP_TEST_DATA_DIR . '/images/test-image.jpg' );
 
 		$this->post_id = wp_insert_post(
@@ -30,13 +29,16 @@ final class CoreImageTest extends PluginTestCase {
 				'post_status'  => 'publish',
 			]
 		);
+
+		\WPGraphQL::clear_schema();
 	}
 
 	public function tearDown(): void {
 		// your tear down methods here
-		parent::tearDown();
-
 		wp_delete_post( $this->post_id, true );
+		\WPGraphQL::clear_schema();
+
+		parent::tearDown();
 	}
 
 	public function test_retrieve_core_image_media_details() {

--- a/tests/unit/CoreTableTest.php
+++ b/tests/unit/CoreTableTest.php
@@ -9,8 +9,6 @@ final class CoreTableTest extends PluginTestCase {
 	public function setUp(): void {
 		parent::setUp();
 
-		global $wpdb;
-
 		$this->post_id = wp_insert_post(
 			[
 				'post_title'   => 'Post Title',
@@ -31,16 +29,18 @@ final class CoreTableTest extends PluginTestCase {
 				'post_status'  => 'publish',
 			]
 		);
+
+		\WPGraphQL::clear_schema();
 	}
 
 	public function tearDown(): void {
-		parent::tearDown();
-
 		wp_delete_post( $this->post_id, true );
+		\WPGraphQL::clear_schema();
+
+		parent::tearDown();
 	}
 
 	public function test_retrieve_core_table_attribute_fields() {
-		$this->markTestSkipped( 'must be revisited since the test is failing on the CI for an unknown reason' );
 		$query = '
 			fragment CoreTableBlockFragment on CoreTable {
 				attributes {

--- a/tests/unit/CoreVideoTest.php
+++ b/tests/unit/CoreVideoTest.php
@@ -9,8 +9,6 @@ final class CoreVideoTest extends PluginTestCase {
 	public function setUp(): void {
 		parent::setUp();
 
-		global $wpdb;
-
 		$this->post_id = wp_insert_post(
 			[
 				'post_title'   => 'Post Title',
@@ -28,17 +26,19 @@ final class CoreVideoTest extends PluginTestCase {
 				'post_status'  => 'publish',
 			]
 		);
+
+		\WPGraphQL::clear_schema();
 	}
 
 	public function tearDown(): void {
 		// your tear down methods here
-		parent::tearDown();
-
 		wp_delete_post( $this->post_id, true );
+		\WPGraphQL::clear_schema();
+
+		parent::tearDown();
 	}
 
 	public function test_retrieve_core_video_attributes() {
-		$this->markTestSkipped( 'must be revisited since the test is failing on the CI for an unknown reason' );
 		$query  = '	
 			fragment CoreVideoBlockFragment on CoreVideo {
 				attributes {

--- a/tests/unit/EditorBlockInterfaceTest.php
+++ b/tests/unit/EditorBlockInterfaceTest.php
@@ -11,10 +11,14 @@ final class EditorBlockInterfaceTest extends PluginTestCase {
 		$settings                                 = get_option( 'graphql_general_settings', [] );
 		$settings['public_introspection_enabled'] = 'on';
 		update_option( 'graphql_general_settings', $settings );
+
+		\WPGraphQL::clear_schema();
 	}
 
 	public function tearDown(): void {
 		// your tear down methods here
+		delete_option( 'graphql_general_settings' );
+		\WPGraphQL::clear_schema();
 
 		// then
 		parent::tearDown();

--- a/tests/unit/PostTypeBlockInterfaceTest.php
+++ b/tests/unit/PostTypeBlockInterfaceTest.php
@@ -20,6 +20,7 @@ final class PostTypeBlockInterfaceTest extends PluginTestCase {
 
 	public function tearDown(): void {
 		// your tear down methods here
+		delete_option( 'graphql_general_settings' );
 		\WPGraphQL::clear_schema();
 
 		parent::tearDown();

--- a/tests/unit/RegistryTestCase.php
+++ b/tests/unit/RegistryTestCase.php
@@ -24,6 +24,7 @@ final class RegistryTestCase extends PluginTestCase {
 
 	public function tearDown(): void {
 		// your tear down methods here
+		delete_option( 'graphql_general_settings' );
 		\WPGraphQL::clear_schema();
 
 		parent::tearDown();

--- a/tests/unit/UpdateCallbacksTest.php
+++ b/tests/unit/UpdateCallbacksTest.php
@@ -1,8 +1,11 @@
 <?php
+
+namespace WPGraphQL\ContentBlocks\Unit;
+
 /**
  * Class UpdateCallbacksTest
  */
-class UpdateCallbacksTest extends WP_UnitTestCase {
+class UpdateCallbacksTest extends PluginTestCase {
 	public function test_pre_set_site_transient_update_plugins_has_filter_added(): void {
 		self::assertSame( 10, has_action( 'pre_set_site_transient_update_plugins', 'WPGraphQL\ContentBlocks\PluginUpdater\check_for_plugin_updates' ) );
 	}


### PR DESCRIPTION
## What

This PR fixes the `::setUp()` and `::tearDown()` methods in our PHPUnit test classes. More specifically
 - The WPGraphQL schema is cleared between each test.
 - Our local tear-downs occur _before_ `parent::tearDown()`
 - We now delete options in `::tearDown()` that were created in `::setUp()`
 - Removed unnecessary `$wpdb` calls.
 
**As a result, `markTestSkipped()` has been removed from `CoreTableTest` and `CoreVideoTest` since they're no longer necessary.**
 
Additionally, the class namespace was added to `UpdateCallbacksTest.php` since the autoload error was bothering me.
 
 ## Why
 
 `CoreImageTest` is for some reason what's causing `CoreTableTest` etc to skip their `attributes` registration, and clearing the WPGraphQL schema allows it to work again.
 
 Made sense to apply it for equal measure, since the underlying issue is lifecycle issue between the plugin/PHPUnit (and not an issue in PHPUnit itself) and we don't want it rearing its head again forcing someone to disable a previously-working test.
 
Additional fixes are low-hanging fruit that don't deserve their own PR or the headache of working around merge conflicts during this sprint.