### PR TITLE
tests : Add tests for `Core Quote` block.

### DIFF
--- a/.changeset/thirty-chicken-drum.md
+++ b/.changeset/thirty-chicken-drum.md
@@ -1,0 +1,5 @@
+---
+"@wpengine/wp-graphql-content-blocks": patch
+---
+
+test : Core Quote block fields and attributes.

--- a/.changeset/thirty-chicken-drum.md
+++ b/.changeset/thirty-chicken-drum.md
@@ -2,4 +2,4 @@
 "@wpengine/wp-graphql-content-blocks": patch
 ---
 
-test : Core Quote block fields and attributes.
+tests : Add tests for `CoreQuote` block.

--- a/tests/unit/CoreQuoteTest.php
+++ b/tests/unit/CoreQuoteTest.php
@@ -107,7 +107,6 @@ final class CoreQuoteTest extends PluginTestCase {
 		];
 
 		$actual = graphql( compact( 'query', 'variables' ) );
-		error_log( print_r( $actual, true ) );
 
 		$this->assertArrayNotHasKey( 'errors', $actual, 'There should not be any errors' );
 		$this->assertArrayHasKey( 'data', $actual, 'The data key should be present' );
@@ -185,7 +184,6 @@ final class CoreQuoteTest extends PluginTestCase {
 		];
 
 		$actual = graphql( compact( 'query', 'variables' ) );
-		error_log( print_r( $actual, true ) );
 
 		$this->assertArrayNotHasKey( 'errors', $actual, 'There should not be any errors' );
 		$this->assertArrayHasKey( 'data', $actual, 'The data key should be present' );
@@ -312,7 +310,6 @@ final class CoreQuoteTest extends PluginTestCase {
 		];
 
 		$actual = graphql( compact( 'query', 'variables' ) );
-		error_log( print_r( $actual, true ) );
 
 		$this->assertArrayNotHasKey( 'errors', $actual, 'There should not be any errors' );
 		$this->assertArrayHasKey( 'data', $actual, 'The data key should be present' );
@@ -407,7 +404,6 @@ final class CoreQuoteTest extends PluginTestCase {
 		];
 
 		$actual = graphql( compact( 'query', 'variables' ) );
-		error_log( print_r( $actual, true ) );
 
 		$this->assertArrayNotHasKey( 'errors', $actual, 'There should not be any errors' );
 		$this->assertArrayHasKey( 'data', $actual, 'The data key should be present' );

--- a/tests/unit/CoreQuoteTest.php
+++ b/tests/unit/CoreQuoteTest.php
@@ -1,0 +1,245 @@
+<?php
+
+namespace WPGraphQL\ContentBlocks\Unit;
+
+final class CoreQuoteTest extends PluginTestCase {
+	/**
+	 * The ID of the post created for the test.
+	 *
+	 * @var int
+	 */
+	public $post_id;
+
+	public function setUp(): void {
+		parent::setUp();
+
+		$this->post_id = wp_insert_post(
+			[
+				'post_title'   => 'Post with Quote',
+				'post_content' => '',
+				'post_status'  => 'publish',
+			]
+		);
+
+		\WPGraphQL::clear_schema();
+	}
+
+	public function tearDown(): void {
+		parent::tearDown();
+
+		wp_delete_post( $this->post_id, true );
+
+		\WPGraphQL::clear_schema();
+	}
+
+	public function query(): string {
+		return '
+			fragment CoreQuoteBlockFragment on CoreQuote {
+				attributes {
+					anchor
+					backgroundColor
+					citation
+					className
+					cssClassName
+					fontFamily
+					fontSize
+					gradient
+					# layout
+					lock
+					# metadata
+					style
+					# textAlign
+					textColor
+					value
+				}
+			}
+
+			query Post( $id: ID! ) {
+				post(id: $id, idType: DATABASE_ID) {
+					databaseId
+					editorBlocks {
+						apiVersion
+						blockEditorCategoryName
+						clientId
+						cssClassNames
+						innerBlocks {
+							name
+						}
+						isDynamic
+						name
+						parentClientId
+						renderedHtml
+						...CoreQuoteBlockFragment
+					}
+				}
+			}
+		';
+	}
+
+	/**
+	 * Test case for retrieving core quote block fields and attributes.
+	 *
+	 * The following aspects are tested:
+	 * - The absence of errors in the GraphQL response.
+	 * - Presence of the 'data' and 'post' keys in the response.
+	 * - Matching post ID.
+	 * - Correct block name ('core/quote').
+	 * - Correct retrieval of the block's attributes, especially 'citation', 'className', 'cssClassName' and 'value'.
+	 *
+	 * @return void
+	 */
+	public function test_retrieve_core_quote_fields_and_attributes() {
+		$block_content = '
+			<!-- wp:quote {"className":"custom-quote-class"} -->
+			<blockquote class="wp-block-quote custom-quote-class"><p>This is a sample quote block content.</p><cite>Author Name</cite></blockquote>
+			<!-- /wp:quote -->
+		';
+
+		// Update the post content with the block content.
+		wp_update_post(
+			[
+				'ID'           => $this->post_id,
+				'post_content' => $block_content,
+			]
+		);
+
+		$query     = $this->query();
+		$variables = [
+			'id' => $this->post_id,
+		];
+
+		$actual = graphql( compact( 'query', 'variables' ) );
+
+		$this->assertArrayNotHasKey( 'errors', $actual, 'There should not be any errors' );
+		$this->assertArrayHasKey( 'data', $actual, 'The data key should be present' );
+		$this->assertArrayHasKey( 'post', $actual['data'], 'The post key should be present' );
+		$this->assertEquals( $this->post_id, $actual['data']['post']['databaseId'], 'The post ID should match' );
+		$this->assertEquals( 1, count( $actual['data']['post']['editorBlocks'] ), 'There should be only one block' );
+
+		$block = $actual['data']['post']['editorBlocks'][0];
+		$this->assertNotEmpty( $block['apiVersion'], 'The apiVersion should be present' );
+		$this->assertEquals( 'text', $block['blockEditorCategoryName'], 'The blockEditorCategoryName should be text' );
+		$this->assertNotEmpty( $block['clientId'], 'The clientId should be present' );
+		$this->assertEquals( $block['cssClassNames'][0], 'custom-quote-class' );
+		$this->assertEmpty( $block['innerBlocks'], 'There should be no inner blocks' );
+		$this->assertEquals( 'core/quote', $block['name'], 'The block name should be core/quote' );
+		$this->assertEmpty( $block['parentClientId'], 'There should be no parentClientId' );
+		$this->assertNotEmpty( $block['renderedHtml'], 'The renderedHtml should be present' );
+
+		// Verify the attributes.
+		$this->assertEquals(
+			[
+				'anchor'          => null,
+				'backgroundColor' => null,
+				'citation'        => 'Author Name',
+				'className'       => 'custom-quote-class',
+				'cssClassName'    => 'wp-block-quote custom-quote-class',
+				'fontFamily'      => null,
+				'fontSize'        => null,
+				'gradient'        => null,
+				'lock'            => null,
+				'style'           => null,
+				'textColor'       => null,
+				'value'           => '<p>This is a sample quote block content.</p>',
+			],
+			$block['attributes'],
+		);
+	}
+
+	/**
+	 * Test case for retrieving core quote block untested attributes.
+	 *
+	 * The following aspects are tested:
+	 * - The absence of errors in the GraphQL response.
+	 * - Presence of the 'data' and 'post' keys in the response.
+	 * - Matching post ID.
+	 * - Correct block name ('core/quote').
+	 * - Correct retrieval of the block's attributes, especially:
+	 *   - 'anchor'
+	 *   - 'backgroundColor'
+	 *   - 'fontFamily'
+	 *   - 'fontSize'
+	 *   - 'gradient'
+	 *   - 'lock'
+	 *   - 'style'
+	 *   - 'textColor'
+	 *
+	 * @return void
+	 */
+	public function test_retrieve_core_quote_attributes() {
+		$block_content = '
+			<!-- wp:quote {"lock":{"move":true,"remove":true},"fontFamily":"body","fontSize":"small","backgroundColor":"pale-cyan-blue","style":{"elements":{"heading":{"color":{"text":"var:preset|color|vivid-cyan-blue","background":"var:preset|color|cyan-bluish-gray"}}}},"textColor":"vivid-red","gradient":"pale-ocean"} -->
+			<blockquote class="wp-block-quote" id="test-anchor"><!-- wp:heading -->
+			<h2 class="wp-block-heading">Quote, with heading color</h2>
+			<!-- /wp:heading --><cite>Citation</cite></blockquote>
+			<!-- /wp:quote -->
+		';
+
+		// Update the post content with the block content.
+		wp_update_post(
+			[
+				'ID'           => $this->post_id,
+				'post_content' => $block_content,
+			]
+		);
+
+		$query     = $this->query();
+		$variables = [
+			'id' => $this->post_id,
+		];
+
+		$actual = graphql( compact( 'query', 'variables' ) );
+
+		$this->assertArrayNotHasKey( 'errors', $actual, 'There should not be any errors' );
+		$this->assertArrayHasKey( 'data', $actual, 'The data key should be present' );
+		$this->assertArrayHasKey( 'post', $actual['data'], 'The post key should be present' );
+		$this->assertEquals( $this->post_id, $actual['data']['post']['databaseId'], 'The post ID should match' );
+
+		// Verify the block data.
+		$block = $actual['data']['post']['editorBlocks'][0];
+		$this->assertNotEmpty( $block['apiVersion'], 'The apiVersion should be present' );
+		$this->assertEquals( 'text', $block['blockEditorCategoryName'], 'The blockEditorCategoryName should be text' );
+		$this->assertNotEmpty( $block['clientId'], 'The clientId should be present' );
+		$this->assertNotEmpty( $block['innerBlocks'], 'There should be no inner blocks' );
+		$this->assertEquals( 'core/quote', $block['name'], 'The block name should be core/quote' );
+		$this->assertEmpty( $block['parentClientId'], 'There should be no parentClientId' );
+		$this->assertNotEmpty( $block['renderedHtml'], 'The renderedHtml should be present' );
+
+		$style = wp_json_encode(
+			[
+				'elements' => [
+					'heading' => [
+						'color' => [
+							'text'       => 'var:preset|color|vivid-cyan-blue',
+							'background' => 'var:preset|color|cyan-bluish-gray',
+						],
+					],
+				],
+			]
+		);
+
+		// Verify the attributes.
+		$this->assertEquals(
+			[
+				'anchor'          => 'test-anchor',
+				'backgroundColor' => 'pale-cyan-blue',
+				'citation'        => 'Citation',
+				'className'       => null,
+				'cssClassName'    => 'wp-block-quote',
+				'fontFamily'      => 'body',
+				'fontSize'        => 'small',
+				'gradient'        => 'pale-ocean',
+				'lock'            => wp_json_encode(
+					[
+						'move'   => true,
+						'remove' => true,
+					]
+				),
+				'style'           => $style,
+				'textColor'       => 'vivid-red',
+				'value'           => '',
+			],
+			$block['attributes'],
+		);
+	}
+}

--- a/tests/unit/CoreQuoteTest.php
+++ b/tests/unit/CoreQuoteTest.php
@@ -51,11 +51,11 @@ final class CoreQuoteTest extends PluginTestCase {
 					fontFamily
 					fontSize
 					gradient
-					# layout
+					layout
 					lock
 					# metadata
 					style
-					# textAlign
+					textAlign
 					textColor
 					value
 				}
@@ -151,6 +151,8 @@ final class CoreQuoteTest extends PluginTestCase {
 				'style'           => null,
 				'textColor'       => null,
 				'value'           => '<p>This is a sample quote block content.</p>',
+				'layout'          => null,
+				'textAlign'       => null,
 			],
 			$block['attributes'],
 		);
@@ -206,14 +208,15 @@ final class CoreQuoteTest extends PluginTestCase {
 		$this->assertEmpty( $block['parentClientId'], 'There should be no parentClientId' );
 		$this->assertNotEmpty( $block['renderedHtml'], 'The renderedHtml should be present' );
 
+		unset( $block['attributes']['citation'] ); // Tested above.
+		unset( $block['attributes']['className'] ); // Tested above.
+		unset( $block['attributes']['cssClassName'] ); // Tested above.
+
 		// Verify the attributes.
 		$this->assertEquals(
 			[
 				'anchor'          => 'test-anchor', // Previously untested.
 				'backgroundColor' => 'pale-cyan-blue', // Previously untested.
-				'citation'        => 'Citation',
-				'className'       => null,
-				'cssClassName'    => 'wp-block-quote',
 				'fontFamily'      => 'body', // Previously untested.
 				'fontSize'        => 'small', // Previously untested.
 				'gradient'        => 'pale-ocean', // Previously untested.
@@ -237,6 +240,8 @@ final class CoreQuoteTest extends PluginTestCase {
 				),
 				'textColor'       => 'vivid-red', // Previously untested.
 				'value'           => '<p>Sample Quote</p>', // Previously untested.
+				'layout'          => null,
+				'textAlign'       => null,
 			],
 			$block['attributes'],
 		);

--- a/tests/unit/CoreQuoteTest.php
+++ b/tests/unit/CoreQuoteTest.php
@@ -149,8 +149,6 @@ final class CoreQuoteTest extends PluginTestCase {
 				'style'           => null,
 				'textColor'       => null,
 				'value'           => '<p>This is a sample quote block content.</p>',
-				// 'layout'          => null,
-				// 'textAlign'       => null,
 			],
 			$block['attributes'],
 		);

--- a/tests/unit/CoreQuoteTest.php
+++ b/tests/unit/CoreQuoteTest.php
@@ -363,7 +363,12 @@ final class CoreQuoteTest extends PluginTestCase {
 		$this->assertEquals(
 			[
 				'value'           => '<p>Sample Quote</p>',
-				'textAlign'       => 'center', // Previously untested.
+				'layout'          => wp_json_encode( // Previously untested.
+					[
+						'type'     => 'flex',
+						'flexWrap' => 'nowrap',
+					]
+				),
 			],
 			$block['attributes'],
 		);
@@ -488,13 +493,13 @@ final class CoreQuoteTest extends PluginTestCase {
 		$this->assertEquals(
 			[
 				'value'           => '<p>Sample Quote</p>',
-				'layout'          => wp_json_encode( // Previously untested.
+				'layout'          => wp_json_encode(
 					[
 						'type'     => 'flex',
 						'flexWrap' => 'nowrap',
 					]
 				),
-				'textAlign'       => 'center',
+				'textAlign'       => 'center', // Previously untested.
 			],
 			$block['attributes'],
 		);

--- a/tests/unit/CoreQuoteTest.php
+++ b/tests/unit/CoreQuoteTest.php
@@ -150,8 +150,8 @@ final class CoreQuoteTest extends PluginTestCase {
 				'style'           => null,
 				'textColor'       => null,
 				'value'           => '<p>This is a sample quote block content.</p>',
-				'layout'          => null,
-				'textAlign'       => null,
+				// 'layout'          => null,
+				// 'textAlign'       => null,
 			],
 			$block['attributes'],
 		);
@@ -253,9 +253,9 @@ final class CoreQuoteTest extends PluginTestCase {
 	 */
 	public function test_retrieve_core_quote_errorneous_attributes(): void {
 		// layout and textAlign are only supported in WP 6.5+.
-		// if ( ! is_wp_version_compatible( '6.6' ) ) {
-		// 	$this->markTestSkipped( 'This test requires WP 6.6 or higher.' );
-		// }
+		if ( ! is_wp_version_compatible( '6.5' ) ) {
+			$this->markTestSkipped( 'This test requires WP 6.6 or higher.' );
+		}
 		$block_content = '
 			<!-- wp:quote {"layout":"test-layout","textAlign":"center"} -->
 			<blockquote class="wp-block-quote" id="test-anchor"><!-- wp:paragraph -->

--- a/tests/unit/CoreQuoteTest.php
+++ b/tests/unit/CoreQuoteTest.php
@@ -251,13 +251,13 @@ final class CoreQuoteTest extends PluginTestCase {
 	 *
 	 * Covers : 'layout' and 'textAlign'.
 	 */
-	public function test_retrieve_core_quote_errorneous_attributes(): void {
+	public function test_retrieve_core_quote_layout_text_align_attributes(): void {
 		// layout and textAlign are only supported in WP 6.5+.
 		if ( ! is_wp_version_compatible( '6.5' ) ) {
 			$this->markTestSkipped( 'This test requires WP 6.6 or higher.' );
 		}
 		$block_content = '
-			<!-- wp:quote {"layout":"test-layout","textAlign":"center"} -->
+			<!-- wp:quote {"layout":{"type":"flex","flexWrap":"nowrap"},"textAlign":"center"} -->
 			<blockquote class="wp-block-quote" id="test-anchor"><!-- wp:paragraph -->
 			<p>Sample Quote</p>
 			<!-- /wp:paragraph --><cite>Citation</cite></blockquote>
@@ -366,7 +366,12 @@ final class CoreQuoteTest extends PluginTestCase {
 		$this->assertEquals(
 			[
 				'value'           => '<p>Sample Quote</p>',
-				'layout'          => 'test-layout', // Previously untested.
+				'layout'          => wp_json_encode( // Previously untested.
+					[
+						'type'     => 'flex',
+						'flexWrap' => 'nowrap',
+					]
+				),
 				'textAlign'       => 'center', // Previously untested.
 			],
 			$block['attributes'],

--- a/tests/unit/CoreQuoteTest.php
+++ b/tests/unit/CoreQuoteTest.php
@@ -51,11 +51,9 @@ final class CoreQuoteTest extends PluginTestCase {
 					fontFamily
 					fontSize
 					gradient
-					layout
 					lock
 					# metadata
 					style
-					textAlign
 					textColor
 					value
 				}
@@ -242,8 +240,87 @@ final class CoreQuoteTest extends PluginTestCase {
 				),
 				'textColor'       => 'vivid-red', // Previously untested.
 				'value'           => '<p>Sample Quote</p>', // Previously untested.
-				'layout'          => null,
-				'textAlign'       => null,
+			],
+			$block['attributes'],
+		);
+	}
+
+
+	/**
+	 * Test case for retrieving core quote block untested attributes.
+	 *
+	 * Covers : 'layout' and 'textAlign'.
+	 */
+	public function test_retrieve_core_quote_errorneous_attributes(): void {
+		// layout and textAlign are only supported in WP 6.5+.
+		// if ( ! is_wp_version_compatible( '6.6' ) ) {
+		// 	$this->markTestSkipped( 'This test requires WP 6.6 or higher.' );
+		// }
+		$block_content = '
+			<!-- wp:quote {"layout":"test-layout","textAlign":"center"} -->
+			<blockquote class="wp-block-quote" id="test-anchor"><!-- wp:paragraph -->
+			<p>Sample Quote</p>
+			<!-- /wp:paragraph --><cite>Citation</cite></blockquote>
+			<!-- /wp:quote -->
+		';
+
+		// Update the post content with the block content.
+		wp_update_post(
+			[
+				'ID'           => $this->post_id,
+				'post_content' => $block_content,
+			]
+		);
+
+		$query     = $this->query();
+		$variables = [
+			'id' => $this->post_id,
+		];
+
+		$actual = graphql( compact( 'query', 'variables' ) );
+		error_log( print_r( $actual, true ) );
+
+		$this->assertArrayNotHasKey( 'errors', $actual, 'There should not be any errors' );
+		$this->assertArrayHasKey( 'data', $actual, 'The data key should be present' );
+		$this->assertArrayHasKey( 'post', $actual['data'], 'The post key should be present' );
+
+		$this->assertEquals( $this->post_id, $actual['data']['post']['databaseId'], 'The post ID should match' );
+
+		// Verify the block data.
+		$block = $actual['data']['post']['editorBlocks'][0];
+
+		$this->assertNotEmpty( $block['apiVersion'], 'The apiVersion should be present' );
+		$this->assertEquals( 'text', $block['blockEditorCategoryName'], 'The blockEditorCategoryName should be text' );
+		$this->assertNotEmpty( $block['clientId'], 'The clientId should be present' );
+
+		$this->assertNotEmpty( $block['innerBlocks'], 'There should be no inner blocks' );
+		$this->assertEquals( 1, count( $block['innerBlocks'] ), 'There should be only one inner block' );
+		$this->assertEquals( 'core/paragraph', $block['innerBlocks'][0]['name'], 'The inner block name should be core/paragraph' );
+
+		$this->assertEquals( 'core/quote', $block['name'], 'The block name should be core/quote' );
+		$this->assertEmpty( $block['parentClientId'], 'There should be no parentClientId' );
+		$this->assertNotEmpty( $block['renderedHtml'], 'The renderedHtml should be present' );
+
+		unset( $block['attributes']['citation'] ); // Tested above.
+		unset( $block['attributes']['className'] ); // Tested above.
+		unset( $block['attributes']['cssClassName'] ); // Tested above.
+
+		unset( $block['attributes']['anchor'] ); // Tested above.
+		unset( $block['attributes']['backgroundColor'] ); // Tested above.
+		unset( $block['attributes']['fontFamily'] ); // Tested above.
+		unset( $block['attributes']['fontSize'] ); // Tested above.
+		unset( $block['attributes']['gradient'] ); // Tested above.
+		unset( $block['attributes']['lock'] ); // Tested above.
+		unset( $block['attributes']['style'] ); // Tested above.
+		unset( $block['attributes']['textColor'] ); // Tested above.
+
+
+		// Verify the attributes.
+		$this->assertEquals(
+			[
+				'value'           => '<p>Sample Quote</p>',
+				'layout'          => 'test-layout', // Previously untested.
+				'textAlign'       => 'test-align', // Previously untested.
 			],
 			$block['attributes'],
 		);

--- a/tests/unit/CoreQuoteTest.php
+++ b/tests/unit/CoreQuoteTest.php
@@ -79,16 +79,9 @@ final class CoreQuoteTest extends PluginTestCase {
 	/**
 	 * Test case for retrieving core quote block fields and attributes.
 	 *
-	 * The following aspects are tested:
-	 * - The absence of errors in the GraphQL response.
-	 * - Presence of the 'data' and 'post' keys in the response.
-	 * - Matching post ID.
-	 * - Correct block name ('core/quote').
-	 * - Correct retrieval of the block's attributes, especially 'citation', 'className', 'cssClassName' and 'value'.
-	 *
-	 * @return void
+	 * Covers : 'citation', 'className', 'cssClassName' and 'value'.
 	 */
-	public function test_retrieve_core_quote_fields_and_attributes() {
+	public function test_retrieve_core_quote_fields_and_attributes(): void {
 		$block_content = '
 			<!-- wp:quote {"className":"custom-quote-class"} -->
 			<blockquote class="wp-block-quote custom-quote-class"><p>This is a sample quote block content.</p><cite>Author Name</cite></blockquote>
@@ -149,24 +142,9 @@ final class CoreQuoteTest extends PluginTestCase {
 	/**
 	 * Test case for retrieving core quote block untested attributes.
 	 *
-	 * The following aspects are tested:
-	 * - The absence of errors in the GraphQL response.
-	 * - Presence of the 'data' and 'post' keys in the response.
-	 * - Matching post ID.
-	 * - Correct block name ('core/quote').
-	 * - Correct retrieval of the block's attributes, especially:
-	 *   - 'anchor'
-	 *   - 'backgroundColor'
-	 *   - 'fontFamily'
-	 *   - 'fontSize'
-	 *   - 'gradient'
-	 *   - 'lock'
-	 *   - 'style'
-	 *   - 'textColor'
-	 *
-	 * @return void
+	 * Covers : 'anchor', 'backgroundColor', 'fontFamily', 'fontSize', 'gradient', 'lock', 'style' and 'textColor'.
 	 */
-	public function test_retrieve_core_quote_attributes() {
+	public function test_retrieve_core_quote_attributes(): void {
 		$block_content = '
 			<!-- wp:quote {"lock":{"move":true,"remove":true},"fontFamily":"body","fontSize":"small","backgroundColor":"pale-cyan-blue","style":{"elements":{"heading":{"color":{"text":"var:preset|color|vivid-cyan-blue","background":"var:preset|color|cyan-bluish-gray"}}}},"textColor":"vivid-red","gradient":"pale-ocean"} -->
 			<blockquote class="wp-block-quote" id="test-anchor"><!-- wp:heading -->
@@ -205,38 +183,36 @@ final class CoreQuoteTest extends PluginTestCase {
 		$this->assertEmpty( $block['parentClientId'], 'There should be no parentClientId' );
 		$this->assertNotEmpty( $block['renderedHtml'], 'The renderedHtml should be present' );
 
-		$style = wp_json_encode(
-			[
-				'elements' => [
-					'heading' => [
-						'color' => [
-							'text'       => 'var:preset|color|vivid-cyan-blue',
-							'background' => 'var:preset|color|cyan-bluish-gray',
-						],
-					],
-				],
-			]
-		);
-
 		// Verify the attributes.
 		$this->assertEquals(
 			[
-				'anchor'          => 'test-anchor',
-				'backgroundColor' => 'pale-cyan-blue',
+				'anchor'          => 'test-anchor', // Previously untested.
+				'backgroundColor' => 'pale-cyan-blue', // Previously untested.
 				'citation'        => 'Citation',
 				'className'       => null,
 				'cssClassName'    => 'wp-block-quote',
-				'fontFamily'      => 'body',
-				'fontSize'        => 'small',
-				'gradient'        => 'pale-ocean',
-				'lock'            => wp_json_encode(
+				'fontFamily'      => 'body', // Previously untested.
+				'fontSize'        => 'small', // Previously untested.
+				'gradient'        => 'pale-ocean', // Previously untested.
+				'lock'            => wp_json_encode( // Previously untested.
 					[
 						'move'   => true,
 						'remove' => true,
 					]
 				),
-				'style'           => $style,
-				'textColor'       => 'vivid-red',
+				'style'           => wp_json_encode( // Previously untested.
+					[
+						'elements' => [
+							'heading' => [
+								'color' => [
+									'text'       => 'var:preset|color|vivid-cyan-blue',
+									'background' => 'var:preset|color|cyan-bluish-gray',
+								],
+							],
+						],
+					]
+				),
+				'textColor'       => 'vivid-red', // Previously untested.
 				'value'           => '',
 			],
 			$block['attributes'],

--- a/tests/unit/CoreQuoteTest.php
+++ b/tests/unit/CoreQuoteTest.php
@@ -272,7 +272,54 @@ final class CoreQuoteTest extends PluginTestCase {
 			]
 		);
 
-		$query     = $this->query();
+		$query     = '
+			fragment CoreQuoteBlockFragment on CoreQuote {
+				innerBlocks {
+					... on CoreParagraph{
+						attributes {
+							content
+						}
+					}
+				}
+				attributes {
+					anchor
+					backgroundColor
+					citation
+					className
+					cssClassName
+					fontFamily
+					fontSize
+					gradient
+					layout
+					lock
+					# metadata
+					style
+					textAlign
+					textColor
+					value
+				}
+			}
+
+			query Post( $id: ID! ) {
+				post(id: $id, idType: DATABASE_ID) {
+					databaseId
+					editorBlocks {
+						apiVersion
+						blockEditorCategoryName
+						clientId
+						cssClassNames
+						innerBlocks {
+							name
+						}
+						isDynamic
+						name
+						parentClientId
+						renderedHtml
+						...CoreQuoteBlockFragment
+					}
+				}
+			}
+		';
 		$variables = [
 			'id' => $this->post_id,
 		];

--- a/tests/unit/CoreQuoteTest.php
+++ b/tests/unit/CoreQuoteTest.php
@@ -109,6 +109,7 @@ final class CoreQuoteTest extends PluginTestCase {
 		];
 
 		$actual = graphql( compact( 'query', 'variables' ) );
+		error_log( print_r( $actual, true ) );
 
 		$this->assertArrayNotHasKey( 'errors', $actual, 'There should not be any errors' );
 		$this->assertArrayHasKey( 'data', $actual, 'The data key should be present' );
@@ -186,6 +187,7 @@ final class CoreQuoteTest extends PluginTestCase {
 		];
 
 		$actual = graphql( compact( 'query', 'variables' ) );
+		error_log( print_r( $actual, true ) );
 
 		$this->assertArrayNotHasKey( 'errors', $actual, 'There should not be any errors' );
 		$this->assertArrayHasKey( 'data', $actual, 'The data key should be present' );

--- a/tests/unit/CoreQuoteTest.php
+++ b/tests/unit/CoreQuoteTest.php
@@ -280,19 +280,8 @@ final class CoreQuoteTest extends PluginTestCase {
 					}
 				}
 				attributes {
-					anchor
-					backgroundColor
-					citation
-					className
-					cssClassName
-					fontFamily
-					fontSize
-					gradient
 					layout
-					lock
 					# metadata
-					style
-					textColor
 					value
 				}
 			}
@@ -317,6 +306,7 @@ final class CoreQuoteTest extends PluginTestCase {
 				}
 			}
 		';
+
 		$variables = [
 			'id' => $this->post_id,
 		];
@@ -333,31 +323,7 @@ final class CoreQuoteTest extends PluginTestCase {
 		// Verify the block data.
 		$block = $actual['data']['post']['editorBlocks'][0];
 
-		$this->assertNotEmpty( $block['apiVersion'], 'The apiVersion should be present' );
-		$this->assertEquals( 'text', $block['blockEditorCategoryName'], 'The blockEditorCategoryName should be text' );
-		$this->assertNotEmpty( $block['clientId'], 'The clientId should be present' );
-
-		$this->assertNotEmpty( $block['innerBlocks'], 'There should be no inner blocks' );
-		$this->assertEquals( 1, count( $block['innerBlocks'] ), 'There should be only one inner block' );
-		$this->assertEquals( 'core/paragraph', $block['innerBlocks'][0]['name'], 'The inner block name should be core/paragraph' );
-
 		$this->assertEquals( 'core/quote', $block['name'], 'The block name should be core/quote' );
-		$this->assertEmpty( $block['parentClientId'], 'There should be no parentClientId' );
-		$this->assertNotEmpty( $block['renderedHtml'], 'The renderedHtml should be present' );
-
-		unset( $block['attributes']['citation'] ); // Tested above.
-		unset( $block['attributes']['className'] ); // Tested above.
-		unset( $block['attributes']['cssClassName'] ); // Tested above.
-
-		unset( $block['attributes']['anchor'] ); // Tested above.
-		unset( $block['attributes']['backgroundColor'] ); // Tested above.
-		unset( $block['attributes']['fontFamily'] ); // Tested above.
-		unset( $block['attributes']['fontSize'] ); // Tested above.
-		unset( $block['attributes']['gradient'] ); // Tested above.
-		unset( $block['attributes']['lock'] ); // Tested above.
-		unset( $block['attributes']['style'] ); // Tested above.
-		unset( $block['attributes']['textColor'] ); // Tested above.
-
 
 		// Verify the attributes.
 		$this->assertEquals(
@@ -409,20 +375,9 @@ final class CoreQuoteTest extends PluginTestCase {
 					}
 				}
 				attributes {
-					anchor
-					backgroundColor
-					citation
-					className
-					cssClassName
-					fontFamily
-					fontSize
-					gradient
 					layout
-					lock
 					# metadata
-					style
 					textAlign
-					textColor
 					value
 				}
 			}
@@ -462,32 +417,7 @@ final class CoreQuoteTest extends PluginTestCase {
 
 		// Verify the block data.
 		$block = $actual['data']['post']['editorBlocks'][0];
-
-		$this->assertNotEmpty( $block['apiVersion'], 'The apiVersion should be present' );
-		$this->assertEquals( 'text', $block['blockEditorCategoryName'], 'The blockEditorCategoryName should be text' );
-		$this->assertNotEmpty( $block['clientId'], 'The clientId should be present' );
-
-		$this->assertNotEmpty( $block['innerBlocks'], 'There should be no inner blocks' );
-		$this->assertEquals( 1, count( $block['innerBlocks'] ), 'There should be only one inner block' );
-		$this->assertEquals( 'core/paragraph', $block['innerBlocks'][0]['name'], 'The inner block name should be core/paragraph' );
-
 		$this->assertEquals( 'core/quote', $block['name'], 'The block name should be core/quote' );
-		$this->assertEmpty( $block['parentClientId'], 'There should be no parentClientId' );
-		$this->assertNotEmpty( $block['renderedHtml'], 'The renderedHtml should be present' );
-
-		unset( $block['attributes']['citation'] ); // Tested above.
-		unset( $block['attributes']['className'] ); // Tested above.
-		unset( $block['attributes']['cssClassName'] ); // Tested above.
-
-		unset( $block['attributes']['anchor'] ); // Tested above.
-		unset( $block['attributes']['backgroundColor'] ); // Tested above.
-		unset( $block['attributes']['fontFamily'] ); // Tested above.
-		unset( $block['attributes']['fontSize'] ); // Tested above.
-		unset( $block['attributes']['gradient'] ); // Tested above.
-		unset( $block['attributes']['lock'] ); // Tested above.
-		unset( $block['attributes']['style'] ); // Tested above.
-		unset( $block['attributes']['textColor'] ); // Tested above.
-
 
 		// Verify the attributes.
 		$this->assertEquals(

--- a/tests/unit/CoreQuoteTest.php
+++ b/tests/unit/CoreQuoteTest.php
@@ -367,7 +367,7 @@ final class CoreQuoteTest extends PluginTestCase {
 			[
 				'value'           => '<p>Sample Quote</p>',
 				'layout'          => 'test-layout', // Previously untested.
-				'textAlign'       => 'test-align', // Previously untested.
+				'textAlign'       => 'center', // Previously untested.
 			],
 			$block['attributes'],
 		);


### PR DESCRIPTION
## What:
This PR backfills tests for the `Core Quote` block and its attributes.

## Tested attributes :

- anchor
- backgroundColor
- citation
- className
- cssClassName
- fontFamily
- fontSize
- gradient
- layout
- lock
- style
- textAlign
- textColor
- value

## Untested fields:
- `CoreQuoteAttributes.metadata` - @todo

## Exposed issues:
NA
