### PR TITLE
tests: Add tests for `CoreParagraph` block

### DIFF
--- a/.changeset/olive-clocks-clean.md
+++ b/.changeset/olive-clocks-clean.md
@@ -1,0 +1,5 @@
+---
+"@wpengine/wp-graphql-content-blocks": patch
+---
+
+tests: Add tests for CoreParagraph block

--- a/tests/unit/CoreParagraphTest.php
+++ b/tests/unit/CoreParagraphTest.php
@@ -1,0 +1,336 @@
+<?php
+
+namespace WPGraphQL\ContentBlocks\Unit;
+
+final class CoreParagraphTest extends PluginTestCase {
+	/**
+	 * The ID of the post created for the test.
+	 *
+	 * @var int
+	 */
+	public $post_id;
+
+	/**
+	 * Set up the test environment.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+
+		$this->post_id = wp_insert_post(
+			[
+				'post_title'   => 'Post with Paragraph',
+				'post_content' => '',
+				'post_status'  => 'publish',
+			]
+		);
+
+		\WPGraphQL::clear_schema();
+	}
+
+	/**
+	 * Tear down the test environment.
+	 */
+	public function tearDown(): void {
+		parent::tearDown();
+
+		wp_delete_post( $this->post_id, true );
+
+		\WPGraphQL::clear_schema();
+	}
+
+	/**
+	 * Provide the GraphQL query for testing.
+	 *
+	 * @return string The GraphQL query.
+	 */
+	public function query(): string {
+		return '
+            fragment CoreParagraphBlockFragment on CoreParagraph {
+                attributes {
+                    align
+                    anchor
+                    backgroundColor
+                    className
+                    content
+                    cssClassName
+                    dropCap
+                    direction
+                    fontFamily
+                    fontSize
+                    gradient
+                    lock
+                    metadata
+                    placeholder
+                    style
+                    textColor
+                }
+            }
+            query Post( $id: ID! ) {
+                post(id: $id, idType: DATABASE_ID) {
+                    databaseId
+                    editorBlocks {
+                        name
+                        ...CoreParagraphBlockFragment
+                    }
+                }
+            }
+        ';
+	}
+
+	/**
+	 * Test the retrieval of core/paragraph block attributes.
+	 *
+	 * Attributes covered:
+	 * - align
+	 * - backgroundColor
+	 * - textColor
+	 * - fontSize
+	 * - fontFamily
+	 * - content
+	 * - cssClassName
+	 *
+	 * @return void
+	 */
+	public function test_retrieve_core_paragraph_attributes() {
+		$block_content = '
+            <!-- wp:paragraph {"align":"center","backgroundColor":"pale-cyan-blue","textColor":"vivid-red","fontSize":"large","fontFamily":"helvetica-arial"} -->
+            <p class="has-text-align-center has-vivid-red-color has-pale-cyan-blue-background-color has-text-color has-background has-large-font-size has-helvetica-arial-font-family">This is a test paragraph with various attributes.</p>
+            <!-- /wp:paragraph -->
+        ';
+
+		wp_update_post(
+			[
+				'ID'           => $this->post_id,
+				'post_content' => $block_content,
+			]
+		);
+
+		$actual = graphql(
+			[
+				'query'     => $this->query(),
+				'variables' => [ 'id' => $this->post_id ],
+			]
+		);
+
+		$this->assertArrayNotHasKey( 'errors', $actual );
+		$this->assertArrayHasKey( 'data', $actual );
+		$this->assertArrayHasKey( 'post', $actual['data'] );
+
+		$block      = $actual['data']['post']['editorBlocks'][0];
+		$attributes = $block['attributes'];
+
+		$this->assertEquals( 'core/paragraph', $block['name'] );
+		$this->assertEquals(
+			[
+				'align'           => 'center',
+				'anchor'          => null,
+				'backgroundColor' => 'pale-cyan-blue',
+				'className'       => null,
+				'content'         => 'This is a test paragraph with various attributes.',
+				'cssClassName'    => 'has-text-align-center has-vivid-red-color has-pale-cyan-blue-background-color has-text-color has-background has-large-font-size has-helvetica-arial-font-family',
+				'dropCap'         => false,
+				'direction'       => null,
+				'fontFamily'      => 'helvetica-arial',
+				'fontSize'        => 'large',
+				'gradient'        => null,
+				'lock'            => null,
+				'metadata'        => null,
+				'placeholder'     => null,
+				'style'           => null,
+				'textColor'       => 'vivid-red',
+			],
+			$attributes
+		);
+	}
+
+	/**
+	 * Test retrieval of core/paragraph block with drop cap and custom styles.
+	 *
+	 * Attributes covered:
+	 * - dropCap
+	 * - style (typography and spacing)
+	 * - content
+	 * - cssClassName
+	 *
+	 * @return void
+	 */
+	public function test_retrieve_core_paragraph_with_drop_cap_and_custom_styles() {
+		$block_content = '
+            <!-- wp:paragraph {"dropCap":true,"style":{"typography":{"lineHeight":"2","textTransform":"uppercase"},"spacing":{"padding":{"top":"20px","right":"20px","bottom":"20px","left":"20px"}}}} -->
+            <p class="has-drop-cap" style="padding-top:20px;padding-right:20px;padding-bottom:20px;padding-left:20px;line-height:2;text-transform:uppercase">This is a paragraph with drop cap and custom styles.</p>
+            <!-- /wp:paragraph -->
+        ';
+
+		wp_update_post(
+			[
+				'ID'           => $this->post_id,
+				'post_content' => $block_content,
+			]
+		);
+
+		$actual = graphql(
+			[
+				'query'     => $this->query(),
+				'variables' => [ 'id' => $this->post_id ],
+			]
+		);
+
+		$block      = $actual['data']['post']['editorBlocks'][0];
+		$attributes = $block['attributes'];
+
+		$this->assertEquals(
+			[
+				'align'           => null,
+				'anchor'          => null,
+				'backgroundColor' => null,
+				'className'       => null,
+				'content'         => 'This is a paragraph with drop cap and custom styles.',
+				'cssClassName'    => 'has-drop-cap',
+				'dropCap'         => true,
+				'direction'       => null,
+				'fontFamily'      => null,
+				'fontSize'        => null,
+				'gradient'        => null,
+				'lock'            => null,
+				'metadata'        => null,
+				'placeholder'     => null,
+				'style'           => wp_json_encode(
+					[
+						'typography' => [
+							'lineHeight'    => '2',
+							'textTransform' => 'uppercase',
+						],
+						'spacing'    => [
+							'padding' => [
+								'top'    => '20px',
+								'right'  => '20px',
+								'bottom' => '20px',
+								'left'   => '20px',
+							],
+						],
+					]
+				),
+				'textColor'       => null,
+			],
+			$attributes
+		);
+	}
+
+	/**
+	 * Test retrieval of core/paragraph block with direction and gradient.
+	 *
+	 * Attributes covered:
+	 * - align
+	 * - direction
+	 * - gradient
+	 * - content
+	 * - cssClassName
+	 *
+	 * @return void
+	 */
+	public function test_retrieve_core_paragraph_with_direction_and_gradient() {
+		$block_content = '
+            <!-- wp:paragraph {"align":"right","direction":"rtl","gradient":"vivid-cyan-blue-to-vivid-purple"} -->
+            <p class="has-text-align-right has-vivid-cyan-blue-to-vivid-purple-gradient-background" style="direction:rtl">This is a right-aligned RTL paragraph with a gradient background.</p>
+            <!-- /wp:paragraph -->
+        ';
+
+		wp_update_post(
+			[
+				'ID'           => $this->post_id,
+				'post_content' => $block_content,
+			]
+		);
+
+		$actual = graphql(
+			[
+				'query'     => $this->query(),
+				'variables' => [ 'id' => $this->post_id ],
+			]
+		);
+
+		$block      = $actual['data']['post']['editorBlocks'][0];
+		$attributes = $block['attributes'];
+
+		$this->assertEquals(
+			[
+				'align'           => 'right',
+				'anchor'          => null,
+				'backgroundColor' => null,
+				'className'       => null,
+				'content'         => 'This is a right-aligned RTL paragraph with a gradient background.',
+				'cssClassName'    => 'has-text-align-right has-vivid-cyan-blue-to-vivid-purple-gradient-background',
+				'dropCap'         => false,
+				'direction'       => 'rtl',
+				'fontFamily'      => null,
+				'fontSize'        => null,
+				'gradient'        => 'vivid-cyan-blue-to-vivid-purple',
+				'lock'            => null,
+				'metadata'        => null,
+				'placeholder'     => null,
+				'style'           => null,
+				'textColor'       => null,
+			],
+			$attributes
+		);
+	}
+
+	/**
+	 * Test retrieval of core/paragraph block with additional attributes.
+	 *
+	 * Attributes covered:
+	 * - anchor
+	 * - className
+	 * - lock
+	 * - metadata
+	 * - placeholder
+	 *
+	 * @return void
+	 */
+	public function test_retrieve_core_paragraph_with_additional_attributes() {
+		$block_content = '
+            <!-- wp:paragraph {"anchor":"test-anchor","className":"custom-class","lock":{"move":true,"remove":true},"metadata":{"someKey":"someValue"},"placeholder":"Type here..."} -->
+            <p class="custom-class" id="test-anchor">This is a paragraph with additional attributes.</p>
+            <!-- /wp:paragraph -->
+        ';
+
+		wp_update_post(
+			[
+				'ID'           => $this->post_id,
+				'post_content' => $block_content,
+			]
+		);
+
+		$actual = graphql(
+			[
+				'query'     => $this->query(),
+				'variables' => [ 'id' => $this->post_id ],
+			]
+		);
+
+		$block      = $actual['data']['post']['editorBlocks'][0];
+		$attributes = $block['attributes'];
+
+		$this->assertEquals(
+			[
+				'align'           => null,
+				'anchor'          => 'test-anchor',
+				'backgroundColor' => null,
+				'className'       => 'custom-class',
+				'content'         => 'This is a paragraph with additional attributes.',
+				'cssClassName'    => 'custom-class',
+				'dropCap'         => false,
+				'direction'       => null,
+				'fontFamily'      => null,
+				'fontSize'        => null,
+				'gradient'        => null,
+				'lock'            => '{"move":true,"remove":true}',
+				'metadata'        => '{"someKey":"someValue"}',
+				'placeholder'     => 'Type here...',
+				'style'           => null,
+				'textColor'       => null,
+			],
+			$attributes
+		);
+	}
+}

--- a/tests/unit/CoreParagraphTest.php
+++ b/tests/unit/CoreParagraphTest.php
@@ -324,7 +324,6 @@ final class CoreParagraphTest extends PluginTestCase {
 	 * - anchor
 	 * - className
 	 * - lock
-	 * - metadata
 	 * - placeholder
 	 *
 	 * @return void

--- a/tests/unit/CoreParagraphTest.php
+++ b/tests/unit/CoreParagraphTest.php
@@ -125,7 +125,6 @@ final class CoreParagraphTest extends PluginTestCase {
 
 		$actual = graphql( compact( 'query', 'variables' ) );
 
-		$this->assertArrayNotHasKey( 'errors', $actual, 'There should not be any errors' );
 		$this->assertArrayHasKey( 'data', $actual, 'The data key should be present' );
 		$this->assertArrayHasKey( 'post', $actual['data'], 'The post key should be present' );
 
@@ -199,9 +198,7 @@ final class CoreParagraphTest extends PluginTestCase {
 		];
 
 		$actual = graphql( compact( 'query', 'variables' ) );
-		error_log( print_r( $actual, true ) );
 
-		$this->assertArrayNotHasKey( 'errors', $actual, 'There should not be any errors' );
 		$this->assertArrayHasKey( 'data', $actual, 'The data key should be present' );
 		$this->assertArrayHasKey( 'post', $actual['data'], 'The post key should be present' );
 
@@ -285,7 +282,6 @@ final class CoreParagraphTest extends PluginTestCase {
 
 		$actual = graphql( compact( 'query', 'variables' ) );
 
-		$this->assertArrayNotHasKey( 'errors', $actual, 'There should not be any errors' );
 		$this->assertArrayHasKey( 'data', $actual, 'The data key should be present' );
 		$this->assertArrayHasKey( 'post', $actual['data'], 'The post key should be present' );
 
@@ -354,7 +350,6 @@ final class CoreParagraphTest extends PluginTestCase {
 
 		$actual = graphql( compact( 'query', 'variables' ) );
 
-		$this->assertArrayNotHasKey( 'errors', $actual, 'There should not be any errors' );
 		$this->assertArrayHasKey( 'data', $actual, 'The data key should be present' );
 		$this->assertArrayHasKey( 'post', $actual['data'], 'The post key should be present' );
 

--- a/tests/unit/CoreParagraphTest.php
+++ b/tests/unit/CoreParagraphTest.php
@@ -59,7 +59,7 @@ final class CoreParagraphTest extends PluginTestCase {
 					fontSize
 					gradient
 					lock
-					metadata
+					# metadata
 					placeholder
 					style
 					textColor
@@ -125,6 +125,7 @@ final class CoreParagraphTest extends PluginTestCase {
 
 		$actual = graphql( compact( 'query', 'variables' ) );
 
+		$this->assertArrayNotHasKey( 'errors', $actual, 'There should not be any errors' );
 		$this->assertArrayHasKey( 'data', $actual, 'The data key should be present' );
 		$this->assertArrayHasKey( 'post', $actual['data'], 'The post key should be present' );
 
@@ -146,22 +147,21 @@ final class CoreParagraphTest extends PluginTestCase {
 		$attributes = $block['attributes'];
 		$this->assertEquals(
 			[
-				'align'           => 'center',
+				'align'           => 'center', // previously untested
 				'anchor'          => null,
-				'backgroundColor' => 'pale-cyan-blue',
+				'backgroundColor' => 'pale-cyan-blue', // previously untested
 				'className'       => null,
-				'content'         => 'This is a test paragraph with various attributes.',
-				'cssClassName'    => 'has-text-align-center has-vivid-red-color has-pale-cyan-blue-background-color has-text-color has-background has-large-font-size has-helvetica-arial-font-family',
+				'content'         => 'This is a test paragraph with various attributes.', // previously untested
+				'cssClassName'    => 'has-text-align-center has-vivid-red-color has-pale-cyan-blue-background-color has-text-color has-background has-large-font-size has-helvetica-arial-font-family', // previously untested
 				'dropCap'         => false,
 				'direction'       => null,
-				'fontFamily'      => 'helvetica-arial',
-				'fontSize'        => 'large',
+				'fontFamily'      => 'helvetica-arial', // previously untested
+				'fontSize'        => 'large', // previously untested
 				'gradient'        => null,
 				'lock'            => null,
-				'metadata'        => null,
 				'placeholder'     => null,
 				'style'           => null,
-				'textColor'       => 'vivid-red',
+				'textColor'       => 'vivid-red', // previously untested
 			],
 			$attributes
 		);
@@ -199,6 +199,7 @@ final class CoreParagraphTest extends PluginTestCase {
 
 		$actual = graphql( compact( 'query', 'variables' ) );
 
+		$this->assertArrayNotHasKey( 'errors', $actual, 'There should not be any errors' );
 		$this->assertArrayHasKey( 'data', $actual, 'The data key should be present' );
 		$this->assertArrayHasKey( 'post', $actual['data'], 'The post key should be present' );
 
@@ -219,15 +220,14 @@ final class CoreParagraphTest extends PluginTestCase {
 				'className'       => null,
 				'content'         => 'This is a paragraph with drop cap and custom styles.',
 				'cssClassName'    => 'has-drop-cap',
-				'dropCap'         => true,
+				'dropCap'         => true, // previously untested
 				'direction'       => null,
 				'fontFamily'      => null,
 				'fontSize'        => null,
 				'gradient'        => null,
 				'lock'            => null,
-				'metadata'        => null,
 				'placeholder'     => null,
-				'style'           => wp_json_encode(
+				'style'           => wp_json_encode( // previously untested
 					[
 						'typography' => [
 							'lineHeight'    => '2',
@@ -282,6 +282,7 @@ final class CoreParagraphTest extends PluginTestCase {
 
 		$actual = graphql( compact( 'query', 'variables' ) );
 
+		$this->assertArrayNotHasKey( 'errors', $actual, 'There should not be any errors' );
 		$this->assertArrayHasKey( 'data', $actual, 'The data key should be present' );
 		$this->assertArrayHasKey( 'post', $actual['data'], 'The post key should be present' );
 
@@ -303,12 +304,11 @@ final class CoreParagraphTest extends PluginTestCase {
 				'content'         => 'This is a right-aligned RTL paragraph with a gradient background.',
 				'cssClassName'    => 'has-text-align-right has-vivid-cyan-blue-to-vivid-purple-gradient-background',
 				'dropCap'         => false,
-				'direction'       => 'rtl',
+				'direction'       => 'rtl', // previously untested
 				'fontFamily'      => null,
 				'fontSize'        => null,
-				'gradient'        => 'vivid-cyan-blue-to-vivid-purple',
+				'gradient'        => 'vivid-cyan-blue-to-vivid-purple', // previously untested
 				'lock'            => null,
-				'metadata'        => null,
 				'placeholder'     => null,
 				'style'           => null,
 				'textColor'       => null,
@@ -350,6 +350,7 @@ final class CoreParagraphTest extends PluginTestCase {
 
 		$actual = graphql( compact( 'query', 'variables' ) );
 
+		$this->assertArrayNotHasKey( 'errors', $actual, 'There should not be any errors' );
 		$this->assertArrayHasKey( 'data', $actual, 'The data key should be present' );
 		$this->assertArrayHasKey( 'post', $actual['data'], 'The post key should be present' );
 
@@ -365,9 +366,9 @@ final class CoreParagraphTest extends PluginTestCase {
 		$this->assertEquals(
 			[
 				'align'           => null,
-				'anchor'          => 'test-anchor',
+				'anchor'          => 'test-anchor', // previously untested
 				'backgroundColor' => null,
-				'className'       => 'custom-class',
+				'className'       => 'custom-class', // previously untested
 				'content'         => 'This is a paragraph with additional attributes.',
 				'cssClassName'    => 'custom-class',
 				'dropCap'         => false,
@@ -375,9 +376,8 @@ final class CoreParagraphTest extends PluginTestCase {
 				'fontFamily'      => null,
 				'fontSize'        => null,
 				'gradient'        => null,
-				'lock'            => '{"move":true,"remove":true}',
-				'metadata'        => '{"someKey":"someValue"}',
-				'placeholder'     => 'Type here...',
+				'lock'            => '{"move":true,"remove":true}', // previously untested
+				'placeholder'     => 'Type here...', // previously untested
 				'style'           => null,
 				'textColor'       => null,
 			],

--- a/tests/unit/CoreParagraphTest.php
+++ b/tests/unit/CoreParagraphTest.php
@@ -199,6 +199,7 @@ final class CoreParagraphTest extends PluginTestCase {
 		];
 
 		$actual = graphql( compact( 'query', 'variables' ) );
+		error_log( print_r( $actual, true ) );
 
 		$this->assertArrayNotHasKey( 'errors', $actual, 'There should not be any errors' );
 		$this->assertArrayHasKey( 'data', $actual, 'The data key should be present' );


### PR DESCRIPTION
## What
This PR adds comprehensive tests for the `CoreParagraph` block and its attributes.

### Tested attributes:
- align
- anchor
- backgroundColor
- className
- content
- cssClassName
- dropCap
- direction
- fontFamily
- fontSize
- gradient
- lock
- placeholder
- style
- textColor

### Untested fields:
- `CoreParagraphAttributes.metadata` - @todo

### Exposed issues:
- None identified during testing. All attributes appear to be correctly implemented and returned as expected.
