### PR TITLE
fix: Ensure correct `EditorBlock.type` field resolution

### DIFF
--- a/.changeset/thin-donuts-float.md
+++ b/.changeset/thin-donuts-float.md
@@ -1,0 +1,5 @@
+---
+"@wpengine/wp-graphql-content-blocks": patch
+---
+
+fix: Ensure correct `EditorBlock.type` field resolution.

--- a/includes/Type/InterfaceType/EditorBlockInterface.php
+++ b/includes/Type/InterfaceType/EditorBlockInterface.php
@@ -141,6 +141,9 @@ final class EditorBlockInterface {
 					'type'                    => [
 						'type'        => 'String',
 						'description' => __( 'The (GraphQL) type of the block', 'wp-graphql-content-blocks' ),
+						'resolve'     => static function ( $block ) {
+							return WPGraphQLHelpers::get_type_name_for_block( $block['blockName'] ?? null );
+						},
 					],
 				],
 				'resolveType'     => static function ( $block ) {

--- a/tests/unit/BlockQueriesTest.php
+++ b/tests/unit/BlockQueriesTest.php
@@ -56,6 +56,7 @@ final class BlockQueriesTest extends PluginTestCase {
 					databaseId
 					editorBlocks(flat: false) {
 						name
+						type
 					}
 				}
 			}
@@ -70,6 +71,7 @@ final class BlockQueriesTest extends PluginTestCase {
 		// There should be only one block using that query when not using flat: true
 		$this->assertEquals( 1, count( $node['editorBlocks'] ) );
 		$this->assertEquals( 'core/columns', $node['editorBlocks'][0]['name'] );
+		$this->assertEquals( 'CoreColumns', $node['editorBlocks'][0]['type'] );
 	}
 
 	public function test_retrieve_flatten_editor_blocks() {
@@ -79,8 +81,9 @@ final class BlockQueriesTest extends PluginTestCase {
 				nodes {
 					databaseId
 					editorBlocks(flat: true) {
-							name
-							parentClientId
+						name
+						parentClientId
+						type
 					}
 				}
 			}
@@ -97,18 +100,23 @@ final class BlockQueriesTest extends PluginTestCase {
 		$this->assertEquals( 5, count( $node['editorBlocks'] ) );
 
 		$this->assertEquals( 'core/columns', $node['editorBlocks'][0]['name'] );
+		$this->assertEquals( 'CoreColumns', $node['editorBlocks'][0]['type'] );
 		$this->assertNull( $node['editorBlocks'][0]['parentClientId'] );
 
 		$this->assertEquals( 'core/column', $node['editorBlocks'][1]['name'] );
+		$this->assertEquals( 'CoreColumn', $node['editorBlocks'][1]['type'] );
 		$this->assertNotNull( $node['editorBlocks'][1]['parentClientId'] );
 
 		$this->assertEquals( 'core/paragraph', $node['editorBlocks'][2]['name'] );
+		$this->assertEquals( 'CoreParagraph', $node['editorBlocks'][2]['type'] );
 		$this->assertNotNull( $node['editorBlocks'][2]['parentClientId'] );
 
 		$this->assertEquals( 'core/column', $node['editorBlocks'][3]['name'] );
+		$this->assertEquals( 'CoreColumn', $node['editorBlocks'][3]['type'] );
 		$this->assertNotNull( $node['editorBlocks'][3]['parentClientId'] );
 
 		$this->assertEquals( 'core/paragraph', $node['editorBlocks'][4]['name'] );
+		$this->assertEquals( 'CoreParagraph', $node['editorBlocks'][4]['type'] );
 		$this->assertNotNull( $node['editorBlocks'][4]['parentClientId'] );
 	}
 }

--- a/tests/unit/BlockSupportsAnchorTest.php
+++ b/tests/unit/BlockSupportsAnchorTest.php
@@ -112,6 +112,7 @@ final class BlockSupportsAnchorTest extends PluginTestCase {
 				nodes {
 					editorBlocks {
 						name
+						type
 						... on BlockWithSupportsAnchor {
 							anchor
 						}
@@ -124,15 +125,19 @@ final class BlockSupportsAnchorTest extends PluginTestCase {
 
 		$this->assertEquals( 4, count( $node['editorBlocks'] ) );
 		$this->assertEquals( 'core/paragraph', $node['editorBlocks'][0]['name'] );
+		$this->assertEquals( 'CoreParagraph', $node['editorBlocks'][0]['type'] );
 		$this->assertEquals( 'example', $node['editorBlocks'][0]['anchor'] );
 
 		$this->assertEquals( 'core/paragraph', $node['editorBlocks'][1]['name'] );
+		$this->assertEquals( 'CoreParagraph', $node['editorBlocks'][1]['type'] );
 		$this->assertNull( $node['editorBlocks'][1]['anchor'] );
 
 		$this->assertEquals( 'core/group', $node['editorBlocks'][2]['name'] );
+		$this->assertEquals( 'CoreGroup', $node['editorBlocks'][2]['type'] );
 		$this->assertNull( $node['editorBlocks'][2]['anchor'] );
 
 		$this->assertEquals( 'core/paragraph', $node['editorBlocks'][3]['name'] );
+		$this->assertEquals( 'CoreParagraph', $node['editorBlocks'][3]['type'] );
 		$this->assertEquals( 'example-inner', $node['editorBlocks'][3]['anchor'] );
 	}
 }

--- a/tests/unit/CoreCodeTest.php
+++ b/tests/unit/CoreCodeTest.php
@@ -80,6 +80,7 @@ final class CoreCodeTest extends PluginTestCase {
 						... on BlockWithSupportsAnchor {
 							anchor
 						}
+						type
 						...CoreCodeBlockFragment
 					}
 				}
@@ -140,6 +141,7 @@ final class CoreCodeTest extends PluginTestCase {
 		$this->assertEmpty( $block['innerBlocks'], 'There should be no inner blocks' );
 		$this->assertEquals( 'core/code', $block['name'], 'The block name should be core/code' );
 		$this->assertEmpty( $block['parentClientId'], 'There should be no parentClientId' );
+		$this->assertEquals( 'CoreCode', $block['type'], 'The block type should be CoreCode' );
 		$this->assertNotEmpty( $block['renderedHtml'], 'The renderedHtml should be present' );
 
 		$attributes = $block['attributes'];
@@ -204,6 +206,7 @@ final class CoreCodeTest extends PluginTestCase {
 		$block = $actual['data']['post']['editorBlocks'][0];
 
 		$this->assertEquals( 'core/code', $block['name'], 'The block name should be core/code' );
+		$this->assertEquals( 'CoreCode', $block['type'], 'The block type should be CoreCode' );
 
 		$attributes = $block['attributes'];
 		$this->assertEquals(
@@ -281,6 +284,7 @@ final class CoreCodeTest extends PluginTestCase {
 		$block = $actual['data']['post']['editorBlocks'][0];
 
 		$this->assertEquals( 'core/code', $block['name'], 'The block name should be core/code' );
+		$this->assertEquals( 'CoreCode', $block['type'], 'The block type should be CoreCode' );
 
 		$attributes = $block['attributes'];
 		$this->assertEquals(

--- a/tests/unit/CoreHeadingTest.php
+++ b/tests/unit/CoreHeadingTest.php
@@ -80,6 +80,7 @@ final class CoreHeadingTest extends PluginTestCase {
 						name
 						parentClientId
 						renderedHtml
+						type
 						... on BlockWithSupportsAnchor {
 							anchor
 						}
@@ -141,6 +142,7 @@ final class CoreHeadingTest extends PluginTestCase {
 		$this->assertEmpty( $block['innerBlocks'], 'There should be no inner blocks' );
 		$this->assertEquals( 'core/heading', $block['name'], 'The block name should be core/heading' );
 		$this->assertEmpty( $block['parentClientId'], 'There should be no parentClientId' );
+		$this->assertEquals( 'CoreHeading', $block['type'], 'The block type should be CoreHeading' );
 		$this->assertNotEmpty( $block['renderedHtml'], 'The renderedHtml should be present' );
 
 		$attributes = $block['attributes'];

--- a/tests/unit/CoreImageTest.php
+++ b/tests/unit/CoreImageTest.php
@@ -86,9 +86,10 @@ final class CoreImageTest extends PluginTestCase {
 						innerBlocks {
 							name
 						}
+						name
 						parentClientId
 						renderedHtml
-						name
+						type
 						...CoreImageBlockFragment
 					}
 				}
@@ -140,6 +141,7 @@ final class CoreImageTest extends PluginTestCase {
 		$this->assertEquals( $this->post_id, $node['databaseId'] );
 		$this->assertEquals( 1, count( $node['editorBlocks'] ) );
 		$this->assertEquals( 'core/image', $node['editorBlocks'][0]['name'] );
+		$this->assertEquals( 'CoreImage', $node['editorBlocks'][0]['type'] );
 
 		$this->assertArrayNotHasKey( 'errors', $actual, 'There should not be any errors' );
 		$this->assertArrayHasKey( 'data', $actual, 'The data key should be present' );
@@ -157,6 +159,7 @@ final class CoreImageTest extends PluginTestCase {
 		$this->assertNotEmpty( $block['cssClassNames'], 'The cssClassNames should be present' );
 		$this->assertEmpty( $block['innerBlocks'], 'There should be no inner blocks' );
 		$this->assertEquals( 'core/image', $block['name'], 'The block name should be core/image' );
+		$this->assertEquals( 'CoreImage', $block['type'], 'The block type should be CoreImage' );
 		$this->assertEmpty( $block['parentClientId'], 'There should be no parentClientId' );
 		$this->assertNotEmpty( $block['renderedHtml'], 'The renderedHtml should be present' );
 		$this->assertEquals(

--- a/tests/unit/CoreListTest.php
+++ b/tests/unit/CoreListTest.php
@@ -85,6 +85,7 @@ final class CoreListTest extends PluginTestCase {
 							name
 							parentClientId
 							renderedHtml
+							type
 							... on CoreListItem {
 								...CoreListItemBlockFragment
 							}
@@ -93,6 +94,7 @@ final class CoreListTest extends PluginTestCase {
 						name
 						parentClientId
 						renderedHtml
+						type
 						...CoreListBlockFragment
 					}
 				}
@@ -149,6 +151,7 @@ final class CoreListTest extends PluginTestCase {
 		$this->assertNotEmpty( $block['cssClassNames'], 'The cssClassNames should be present' );
 
 		$this->assertEquals( 'core/list', $block['name'], 'The block name should be core/list' );
+		$this->assertEquals( 'CoreList', $block['type'], 'The block type should be CoreList' );
 		$this->assertEmpty( $block['parentClientId'], 'There should be no parentClientId' );
 		$this->assertNotEmpty( $block['renderedHtml'], 'The renderedHtml should be present' );
 
@@ -184,6 +187,7 @@ final class CoreListTest extends PluginTestCase {
 		$this->assertEmpty( $block['innerBlocks'][0]['cssClassNames'], 'The cssClassNames should be present' );
 		$this->assertNotEmpty( $block['innerBlocks'][0]['clientId'], 'The clientId should be present' );
 		$this->assertEquals( 'core/list-item', $block['innerBlocks'][0]['name'], 'The block name should be core/list-item' );
+		$this->assertEquals( 'CoreListItem', $block['innerBlocks'][0]['type'], 'The block type should be CoreListItem' );
 		$this->assertNotEmpty( $block['innerBlocks'][0]['renderedHtml'], 'The renderedHtml should be present' );
 
 		$this->assertEquals(
@@ -250,6 +254,7 @@ final class CoreListTest extends PluginTestCase {
 		$block = $actual['data']['post']['editorBlocks'][0];
 
 		$this->assertEquals( 'core/list', $block['name'], 'The block name should be core/list' );
+		$this->assertEquals( 'CoreList', $block['type'], 'The block type should be CoreList' );
 
 		$this->assertEquals(
 			[
@@ -318,6 +323,7 @@ final class CoreListTest extends PluginTestCase {
 		$block = $actual['data']['post']['editorBlocks'][0];
 
 		$this->assertEquals( 'core/list', $block['name'], 'The block name should be core/list' );
+		$this->assertEquals( 'CoreList', $block['type'], 'The block type should be CoreList' );
 
 		$this->assertEquals(
 			[
@@ -383,6 +389,7 @@ final class CoreListTest extends PluginTestCase {
 		$block = $actual['data']['post']['editorBlocks'][0];
 
 		$this->assertEquals( 'core/list', $block['name'], 'The block name should be core/list' );
+		$this->assertEquals( 'CoreList', $block['type'], 'The block type should be CoreList' );
 
 		$this->assertEquals(
 			[
@@ -653,6 +660,7 @@ final class CoreListTest extends PluginTestCase {
 					editorBlocks( flat: false ) {
 						clientId
 						name
+						type
 						parentClientId
 						innerBlocks {
 							... on CoreListItem {

--- a/tests/unit/CoreParagraphTest.php
+++ b/tests/unit/CoreParagraphTest.php
@@ -80,6 +80,7 @@ final class CoreParagraphTest extends PluginTestCase {
 						name
 						parentClientId
 						renderedHtml
+						type
 						... on BlockWithSupportsAnchor {
 							anchor
 						}
@@ -141,6 +142,7 @@ final class CoreParagraphTest extends PluginTestCase {
 
 		$this->assertEmpty( $block['innerBlocks'], 'There should be no inner blocks' );
 		$this->assertEquals( 'core/paragraph', $block['name'], 'The block name should be core/paragraph' );
+		$this->assertEquals( 'CoreParagraph', $block['type'], 'The block type should be CoreParagraph' );
 		$this->assertEmpty( $block['parentClientId'], 'There should be no parentClientId' );
 		$this->assertNotEmpty( $block['renderedHtml'], 'The renderedHtml should be present' );
 
@@ -210,6 +212,7 @@ final class CoreParagraphTest extends PluginTestCase {
 		$block = $actual['data']['post']['editorBlocks'][0];
 
 		$this->assertEquals( 'core/paragraph', $block['name'], 'The block name should be core/paragraph' );
+		$this->assertEquals( 'CoreParagraph', $block['type'], 'The block type should be CoreParagraph' );
 
 		$attributes = $block['attributes'];
 		$this->assertEquals(
@@ -293,6 +296,7 @@ final class CoreParagraphTest extends PluginTestCase {
 		$block = $actual['data']['post']['editorBlocks'][0];
 
 		$this->assertEquals( 'core/paragraph', $block['name'], 'The block name should be core/paragraph' );
+		$this->assertEquals( 'CoreParagraph', $block['type'], 'The block type should be CoreParagraph' );
 
 		$attributes = $block['attributes'];
 		$this->assertEquals(
@@ -360,6 +364,7 @@ final class CoreParagraphTest extends PluginTestCase {
 		$block = $actual['data']['post']['editorBlocks'][0];
 
 		$this->assertEquals( 'core/paragraph', $block['name'], 'The block name should be core/paragraph' );
+		$this->assertEquals( 'CoreParagraph', $block['type'], 'The block type should be CoreParagraph' );
 
 		$attributes = $block['attributes'];
 		$this->assertEquals(

--- a/tests/unit/CorePreformattedTest.php
+++ b/tests/unit/CorePreformattedTest.php
@@ -75,6 +75,7 @@ final class CorePreformattedTest extends PluginTestCase {
 						name
 						parentClientId
 						renderedHtml
+						type
 						... on BlockWithSupportsAnchor {
 							anchor
 						}
@@ -138,6 +139,7 @@ preformatted block
 
 		$this->assertEmpty( $block['innerBlocks'], 'There should be no inner blocks' );
 		$this->assertEquals( 'core/preformatted', $block['name'], 'The block name should be core/preformatted' );
+		$this->assertEquals( 'CorePreformatted', $block['type'], 'The block type should be CorePreformatted' );
 		$this->assertEmpty( $block['parentClientId'], 'There should be no parentClientId' );
 		$this->assertNotEmpty( $block['renderedHtml'], 'The renderedHtml should be present' );
 
@@ -203,6 +205,7 @@ and custom border style.</pre>
 		$block = $actual['data']['post']['editorBlocks'][0];
 
 		$this->assertEquals( 'core/preformatted', $block['name'], 'The block name should be core/preformatted' );
+		$this->assertEquals( 'CorePreformatted', $block['type'], 'The block type should be CorePreformatted' );
 
 		$attributes = $block['attributes'];
 		$this->assertEquals(
@@ -278,6 +281,7 @@ with metadata.</pre>
 		$block = $actual['data']['post']['editorBlocks'][0];
 
 		$this->assertEquals( 'core/preformatted', $block['name'], 'The block name should be core/preformatted' );
+		$this->assertEquals( 'CorePreformatted', $block['type'], 'The block type should be CorePreformatted' );
 
 		$attributes = $block['attributes'];
 		$this->assertEquals(

--- a/tests/unit/CoreQuoteTest.php
+++ b/tests/unit/CoreQuoteTest.php
@@ -73,6 +73,7 @@ final class CoreQuoteTest extends PluginTestCase {
 						isDynamic
 						name
 						parentClientId
+						type
 						renderedHtml
 						...CoreQuoteBlockFragment
 					}
@@ -126,6 +127,7 @@ final class CoreQuoteTest extends PluginTestCase {
 
 		$this->assertEmpty( $block['innerBlocks'], 'There should be no inner blocks' );
 		$this->assertEquals( 'core/quote', $block['name'], 'The block name should be core/quote' );
+		$this->assertEquals( 'CoreQuote', $block['type'], 'The block type should be CoreQuote' );
 		$this->assertEmpty( $block['parentClientId'], 'There should be no parentClientId' );
 		$this->assertNotEmpty( $block['renderedHtml'], 'The renderedHtml should be present' );
 
@@ -201,6 +203,7 @@ final class CoreQuoteTest extends PluginTestCase {
 		$this->assertEquals( 'core/paragraph', $block['innerBlocks'][0]['name'], 'The inner block name should be core/paragraph' );
 
 		$this->assertEquals( 'core/quote', $block['name'], 'The block name should be core/quote' );
+		$this->assertEquals( 'CoreQuote', $block['type'], 'The block type should be CoreQuote' );
 		$this->assertEmpty( $block['parentClientId'], 'There should be no parentClientId' );
 		$this->assertNotEmpty( $block['renderedHtml'], 'The renderedHtml should be present' );
 

--- a/tests/unit/CoreSeparatorTest.php
+++ b/tests/unit/CoreSeparatorTest.php
@@ -64,6 +64,7 @@ final class CoreSeparatorTest extends PluginTestCase {
 						name
 						parentClientId
 						renderedHtml
+						type
 						...CoreSeparatorBlockFragment
 					}
 				}
@@ -111,6 +112,7 @@ final class CoreSeparatorTest extends PluginTestCase {
 		$this->assertNotEmpty( $block['cssClassNames'], 'There should be cssClassNames' );
 		$this->assertEmpty( $block['innerBlocks'], 'There should be no inner blocks' );
 		$this->assertEquals( 'core/separator', $block['name'], 'The block name should be core/separator' );
+		$this->assertEquals( 'CoreSeparator', $block['type'], 'The block type should be CoreSeparator' );
 		$this->assertEmpty( $block['parentClientId'], 'There should be no parentClientId' );
 		$this->assertNotEmpty( $block['renderedHtml'], 'The renderedHtml should be present' );
 
@@ -175,6 +177,7 @@ final class CoreSeparatorTest extends PluginTestCase {
 		$this->assertEquals( $this->post_id, $actual['data']['post']['databaseId'], 'The post ID should match' );
 		$this->assertEquals( 1, count( $actual['data']['post']['editorBlocks'] ) );
 		$this->assertEquals( 'core/separator', $actual['data']['post']['editorBlocks'][0]['name'], 'The block name should be core/separator' );
+		$this->assertEquals( 'CoreSeparator', $actual['data']['post']['editorBlocks'][0]['type'], 'The block type should be CoreSeparator' );
 
 		// Verify the attributes.
 		$this->assertEquals(

--- a/tests/unit/CoreTableTest.php
+++ b/tests/unit/CoreTableTest.php
@@ -85,6 +85,7 @@ final class CoreTableTest extends PluginTestCase {
 						name
 						parentClientId
 						renderedHtml
+						type
 						... on BlockWithSupportsAnchor {
 							anchor
 						}
@@ -145,6 +146,7 @@ final class CoreTableTest extends PluginTestCase {
 
 		$this->assertEmpty( $block['innerBlocks'], 'There should be no inner blocks' );
 		$this->assertEquals( 'core/table', $block['name'], 'The block name should be core/table' );
+		$this->assertEquals( 'CoreTable', $block['type'], 'The block type should be CoreTable' );
 		$this->assertEmpty( $block['parentClientId'], 'There should be no parentClientId' );
 		$this->assertNotEmpty( $block['renderedHtml'], 'The renderedHtml should be present' );
 

--- a/tests/unit/CoreVideoTest.php
+++ b/tests/unit/CoreVideoTest.php
@@ -71,6 +71,7 @@ final class CoreVideoTest extends PluginTestCase {
 						}
 						parentClientId
 						renderedHtml
+						type
 						...CoreVideoBlockFragment
 					}
 				}
@@ -137,6 +138,7 @@ final class CoreVideoTest extends PluginTestCase {
 		$this->assertNotEmpty( $block['cssClassNames'], 'The cssClassNames should be present' );
 		$this->assertEmpty( $block['innerBlocks'], 'There should be no inner blocks' );
 		$this->assertEquals( 'core/video', $block['name'], 'The block name should be core/video' );
+		$this->assertEquals( 'CoreVideo', $block['type'], 'The block type should be CoreVideo' );
 		$this->assertEmpty( $block['parentClientId'], 'There should be no parentClientId' );
 		$this->assertNotEmpty( $block['renderedHtml'], 'The renderedHtml should be present' );
 


### PR DESCRIPTION
## What

This PR fixes a regression in #285 where the `type` field was exposed with no resolve method, cause the field to always return null.

## Why

In the upstream branch I'm hydrating blocks with a model, but we need an explicit resolve function until that's merged.

