### PR TITLE
ci: test against WordPress 6.7

### DIFF
--- a/.github/workflows/test-plugin-nightly.yml
+++ b/.github/workflows/test-plugin-nightly.yml
@@ -16,11 +16,11 @@ jobs:
       - name: Create Docker Containers
         env:
           PHP_VERSION: 8.2
-          WP_VERSION: 6.6
+          WP_VERSION: 6.7
         working-directory: ./
         run: |
           docker compose build \
-            --build-arg WP_VERSION=6.6 \
+            --build-arg WP_VERSION=6.7 \
             --build-arg PHP_VERSION=8.2
           docker compose up -d
 

--- a/.github/workflows/test-plugin.yml
+++ b/.github/workflows/test-plugin.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         php: [ '8.2', '7.4' ]
-        wordpress: [ '6.6','6.5', '6.4', '6.3', '6.2', '6.1' ]
+        wordpress: [ '6.7', '6.6','6.5', '6.4', '6.3', '6.2', '6.1' ]
         exclude:
         - php: 8.2
           wordpress: 6.1

--- a/.github/workflows/test-plugin.yml
+++ b/.github/workflows/test-plugin.yml
@@ -26,6 +26,8 @@ jobs:
           wordpress: 6.5
         - php: 7.4
           wordpress: 6.6
+        - php: 7.4
+          wordpress: 6.7
       fail-fast: false
     name: WordPress ${{ matrix.wordpress }}, PHP ${{ matrix.php }}
     steps:

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: blakewpe, chriswiegman, joefusco, matthewguywright, TeresaGobble, thdespou, wpengine
 Tags: faustjs, faust, headless, decoupled, gutenberg
 Requires at least: 5.7
-Tested up to: 6.7
+Tested up to: 6.7.1
 Stable tag: 4.3.1
 Requires PHP: 7.4
 License: GPLv2 or later

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: blakewpe, chriswiegman, joefusco, matthewguywright, TeresaGobble, thdespou, wpengine
 Tags: faustjs, faust, headless, decoupled, gutenberg
 Requires at least: 5.7
-Tested up to: 6.6.2
+Tested up to: 6.7
 Stable tag: 4.3.1
 Requires PHP: 7.4
 License: GPLv2 or later


### PR DESCRIPTION
## What

This PR bumps the `Tested up to` header and various CI variables to WordPress `6.7`.