### PR TITLE
feat: add support for resolving PostContent blocks

### DIFF
--- a/.changeset/itchy-mugs-sniff.md
+++ b/.changeset/itchy-mugs-sniff.md
@@ -1,0 +1,5 @@
+---
+"@wpengine/wp-graphql-content-blocks": minor
+---
+
+feat: add support for resolving PostContent blocks

--- a/includes/Data/ContentBlocksResolver.php
+++ b/includes/Data/ContentBlocksResolver.php
@@ -149,8 +149,8 @@ final class ContentBlocksResolver {
 
 		// @todo apply more hydrations.
 		$block = self::populate_template_part_inner_blocks( $block );
+		$block = self::populate_post_content_inner_blocks( $block );
 		$block = self::populate_reusable_blocks( $block );
-
 		$block = self::populate_pattern_inner_blocks( $block );
 
 		// Prepare innerBlocks.
@@ -209,6 +209,35 @@ final class ContentBlocksResolver {
 		}
 
 		$block['innerBlocks'] = $template_blocks;
+
+		return $block;
+	}
+
+	/**
+	 * Populates the innerBlocks of a core/post-content block with the blocks from the post content.
+	 *
+	 * @param array<string,mixed> $block The block to populate.
+	 *
+	 * @return array<string,mixed> The populated block.
+	 */
+	private static function populate_post_content_inner_blocks( array $block ): array {
+		if ( 'core/post-content' !== $block['blockName'] ) {
+			return $block;
+		}
+
+		$post = get_post();
+
+		if ( ! $post ) {
+			return $block;
+		}
+
+		$parsed_blocks = ! empty( $post->post_content ) ? self::parse_blocks( $post->post_content ) : null;
+
+		if ( empty( $parsed_blocks ) ) {
+			return $block;
+		}
+
+		$block['innerBlocks'] = $parsed_blocks;
 
 		return $block;
 	}


### PR DESCRIPTION
## What

This PR adds support for resolving `innerBlocks` for `core/post-content` blocks.

> [!IMPORTANT]
> This PR is based off of https://github.com/wpengine/wp-graphql-content-blocks/pull/324, which should be merged first.
> Relevant diff: 8e2e921850d709092e6f051f88d7d5a9d239841b

## Why

This is _essential_ for supporting FSE, and due to the `final`/`private` nature of `ContentBlocksResolver` cannot be easily hooked in from external code.

While the WPGraphQL core does not (yet) support querying for a complete FSE template (where `core/post-content` is traditionally used, I believe the above consideration along with the following reasons still make this a good candidate for inclusion:
1. While an unlikely edge case, the fact that it's replicable in the tests using public hooks and functions means it not premature for inclusion.
2. It has the added benefit of giving us a real-world test case for the `wpgraphql_content_blocks_resolver_content`, that goes along with validating the `@todo` in [the `Post` model gate](https://github.com/wpengine/wp-graphql-content-blocks/blob/main/includes/Data/ContentBlocksResolver.php#L43)
3. As with the two proceeding PRs, this is a _backwards-compatible_ enhancement (also future compatible with FSE), so it makes sense to add it before a pending breaking release.

**Note:* This PR is based on #324 solely to prevent merge conflicts. There are no code dependencies between the commits.