### PR TITLE
feat: Added cssClassName attribute to CoreGroup

### DIFF
--- a/.changeset/proud-fireants-buy.md
+++ b/.changeset/proud-fireants-buy.md
@@ -1,0 +1,5 @@
+---
+"@wpengine/wp-graphql-content-blocks": patch
+---
+
+feat: Added a `CoreGroup` block class to fix an issue with a missing attribute `cssClassName`

--- a/includes/Blocks/CoreGroup.php
+++ b/includes/Blocks/CoreGroup.php
@@ -1,0 +1,28 @@
+<?php
+/**
+ * Core Group Block
+ *
+ * @package WPGraphQL\ContentBlocks\Blocks
+ */
+
+namespace WPGraphQL\ContentBlocks\Blocks;
+
+/**
+ * Class CoreGroup
+ */
+class CoreGroup extends Block {
+	/**
+	 * {@inheritDoc}
+	 *
+	 * Note that no selector is set as it can be a variety of selectors
+	 *
+	 * @var array|null
+	 */
+	protected ?array $additional_block_attributes = [
+		'cssClassName' => [
+			'type'      => 'string',
+			'source'    => 'attribute',
+			'attribute' => 'class',
+		],
+	];
+}

--- a/tests/unit/CoreGroupTest.php
+++ b/tests/unit/CoreGroupTest.php
@@ -1,0 +1,197 @@
+<?php
+
+namespace WPGraphQL\ContentBlocks\Unit;
+
+/**
+ * @group block
+ * @group core-group
+ */
+final class CoreGroupTest extends PluginTestCase {
+
+	/**
+	 * The ID of the post created for the test.
+	 *
+	 * @var int
+	 */
+	public $post_id;
+
+	/**
+	 * The ID of the attachment created for the test.
+	 *
+	 * @var int
+	 */
+	public $attachment_id;
+
+	public function setUp(): void {
+		parent::setUp();
+
+		$this->post_id = wp_insert_post(
+			[
+				'post_title'   => 'Post Title',
+				'post_content' => '',
+				'post_status'  => 'publish',
+			]
+		);
+
+		\WPGraphQL::clear_schema();
+	}
+
+	public function tearDown(): void {
+		// your tear down methods here
+		wp_delete_post( $this->post_id, true );
+		\WPGraphQL::clear_schema();
+
+		parent::tearDown();
+	}
+
+	/**
+	 * Get the query for the CoreGroup block.
+	 *
+	 * @param string $attributes The attributes to add to query.
+	 */
+	public function query(): string {
+		return '
+			fragment CoreGroupFragment on CoreGroup {
+			  attributes {
+			    align
+			    backgroundColor
+			    borderColor
+			    className
+			    cssClassName
+			    fontFamily
+			    fontSize
+			    gradient
+			    layout
+			    lock
+			    style
+			    tagName
+			    textColor	
+			  }
+			}
+			
+			query Post($id: ID!) {
+			  post(id: $id, idType: DATABASE_ID) {
+			    databaseId
+			    editorBlocks(flat:true) {
+			      apiVersion
+			      blockEditorCategoryName
+			      clientId
+			      cssClassNames
+			      innerBlocks {
+			        name
+			      }
+			      name
+			      parentClientId
+			      renderedHtml
+			      type
+			      ...CoreGroupFragment
+			    }
+			  }
+			}
+		';
+	}
+
+	/**
+	 * Test that the CoreGroup block is retrieved correctly.
+	 *
+	 * Covers the following attributes:
+	 * - apiVersion
+	 * - blockEditorCategoryName
+	 * - clientId
+	 * - cssClassNames
+	 * - innerBlocks
+	 * - name
+	 * - parentClientId
+	 * - renderedHtml
+	 * - type
+	 * - attributes
+	 */
+
+	public function test_retrieve_core_image_fields_attributes(): void {
+		$block_content = <<<HTML
+<!-- wp:group {"tagName":"header","className":"test-group-class is-style-default","layout":{"type":"flex","flexWrap":"wrap","justifyContent":"center"}} -->
+<header id="test-group-id" class="wp-block-group test-group-class is-style-default"><!-- wp:paragraph -->
+<p>This is the left paragraph.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p>This is the right paragraph</p>
+<!-- /wp:paragraph --></header>
+<!-- /wp:group -->
+
+<!-- wp:paragraph {"className":"example-class"} -->
+<p class="example-class">This is an example page. It's different from a blog post because it will stay in one place and will show up in your site navigation (in most themes). Most people start with an About page that introduces them to potential site visitors. It might say something like this:</p>
+<!-- /wp:paragraph -->
+HTML;
+
+		$query = $this->query();
+
+		// Update the post content with the block content.
+		wp_update_post(
+			[
+				'ID'           => $this->post_id,
+				'post_content' => $block_content,
+			]
+		);
+
+		$variables = [
+			'id' => $this->post_id,
+		];
+
+		$actual = graphql( compact( 'query', 'variables' ) );
+		$this->assertArrayNotHasKey( 'errors', $actual, 'There should not be any errors' );
+		$this->assertArrayHasKey( 'data', $actual, 'The data key should be present' );
+		$this->assertArrayHasKey( 'post', $actual['data'], 'The post key should be present' );
+		$node = $actual['data']['post'];
+
+
+		// Verify that the ID of the first post matches the one we just created.
+		$this->assertEquals( $this->post_id, $node['databaseId'], 'The post ID should match' );
+		$this->assertEquals( 'core/group', $node['editorBlocks'][0]['name'], 'The block name should match core/group' );
+		$this->assertEquals( 'CoreGroup', $node['editorBlocks'][0]['type'], 'The block type should match CoreGroup' );
+		$this->assertNotEmpty( $node['editorBlocks'], 'The node should have an array with the key editorBlocks which is not empty' );
+
+		// Check Block nodes
+		$block = $node['editorBlocks'][0];
+		$this->assertNotEmpty( $block['apiVersion'], 'The apiVersion should be present' );
+		$this->assertEquals( 'design', $block['blockEditorCategoryName'], 'The blockEditorCategoryName should be media' );
+		$this->assertNotEmpty( $block['clientId'], 'The clientId should be present' );
+		$this->assertNotEmpty( $block['cssClassNames'], 'The cssClassNames should be present' );
+		$this->assertNotEmpty( $block['innerBlocks'], 'The innerBlocks should be an array' );
+		$this->assertEmpty( $block['parentClientId'], 'There should be no parentClientId' );
+		$this->assertNotEmpty( $block['renderedHtml'], 'The renderedHtml should be present' );
+
+
+		// Check child blocks
+		$clientId = $block['clientId'];
+		$childBlock1 = $node['editorBlocks'][1];
+		$this->assertNotEmpty( $childBlock1, 'Child block 1 should be present' );
+		$this->assertEquals( $clientId, $childBlock1['parentClientId'], 'Child block 1 parentClientId should match the parent block clientId' );
+		$this->assertEquals('core/paragraph', $childBlock1['name'], 'Child block 1 should be a core/paragraph' );
+
+		$childBlock2 = $node['editorBlocks'][1];
+		$this->assertNotEmpty( $childBlock2, 'Child block 2 should be present' );
+		$this->assertEquals( $clientId, $childBlock1['parentClientId'], 'Child block 2 parentClientId should match the parent block clientId' );
+		$this->assertEquals('core/paragraph', $childBlock1['name'], 'Child block 2 should be a core/paragraph' );
+
+		// Check attributes
+		$this->assertEquals(
+			[
+				"align"           => null,
+				"backgroundColor" => null,
+				"borderColor"     => null,
+				"className"       => "test-group-class is-style-default",
+				"cssClassName"    => "wp-block-group test-group-class is-style-default is-content-justification-center is-layout-flex wp-container-7",
+				"fontFamily"      => null,
+				"fontSize"        => null,
+				"gradient"        => null,
+				"layout"          => "{\"type\":\"flex\",\"flexWrap\":\"wrap\",\"justifyContent\":\"center\"}",
+				"lock"            => null,
+				'style'           => null,
+				"tagName"         => "header",
+				"textColor"       => null
+			],
+			$node['editorBlocks'][0]['attributes']
+		);
+	}
+}

--- a/tests/unit/CoreGroupTest.php
+++ b/tests/unit/CoreGroupTest.php
@@ -161,7 +161,6 @@ HTML;
 		$this->assertEmpty( $block['parentClientId'], 'There should be no parentClientId' );
 		$this->assertNotEmpty( $block['renderedHtml'], 'The renderedHtml should be present' );
 
-
 		// Check child blocks
 		$clientId = $block['clientId'];
 		$childBlock1 = $node['editorBlocks'][1];
@@ -175,23 +174,17 @@ HTML;
 		$this->assertEquals('core/paragraph', $childBlock1['name'], 'Child block 2 should be a core/paragraph' );
 
 		// Check attributes
-		$this->assertEquals(
-			[
-				"align"           => null,
-				"backgroundColor" => null,
-				"borderColor"     => null,
-				"className"       => "test-group-class is-style-default",
-				"cssClassName"    => "wp-block-group test-group-class is-style-default is-content-justification-center is-layout-flex wp-container-7",
-				"fontFamily"      => null,
-				"fontSize"        => null,
-				"gradient"        => null,
-				"layout"          => "{\"type\":\"flex\",\"flexWrap\":\"wrap\",\"justifyContent\":\"center\"}",
-				"lock"            => null,
-				'style'           => null,
-				"tagName"         => "header",
-				"textColor"       => null
-			],
-			$node['editorBlocks'][0]['attributes']
-		);
+		$blockAttributes = $node['editorBlocks'][0]['attributes'];
+		$this->assertEquals(null, $blockAttributes['align']);
+		$this->assertEquals(null, $blockAttributes['backgroundColor']);
+		$this->assertEquals(null, $blockAttributes['borderColor']);
+		$this->assertEquals('test-group-class is-style-default', $blockAttributes['className']);
+		$this->assertStringContainsString('wp-block-group test-group-class is-style-default', $blockAttributes['cssClassName']); // Class name varies slightly between WP versions
+		$this->assertEquals(null, $blockAttributes['fontFamily']);
+		$this->assertEquals(null, $blockAttributes['fontSize']);
+		$this->assertEquals("{\"type\":\"flex\",\"flexWrap\":\"wrap\",\"justifyContent\":\"center\"}", $blockAttributes['layout']);
+		$this->assertEquals(null, $blockAttributes['style']);
+		$this->assertEquals('header', $blockAttributes['tagName']);
+		$this->assertEquals(null, $blockAttributes['textColor']);
 	}
 }

--- a/tests/unit/CoreGroupTest.php
+++ b/tests/unit/CoreGroupTest.php
@@ -107,7 +107,7 @@ final class CoreGroupTest extends PluginTestCase {
 	 * - attributes
 	 */
 
-	public function test_retrieve_core_image_fields_attributes(): void {
+	public function test_retrieve_core_group_fields_attributes(): void {
 		$block_content = <<<HTML
 <!-- wp:group {"tagName":"header","className":"test-group-class is-style-default","layout":{"type":"flex","flexWrap":"wrap","justifyContent":"center"}} -->
 <header id="test-group-id" class="wp-block-group test-group-class is-style-default"><!-- wp:paragraph -->


### PR DESCRIPTION
## Overview

This adds the cssClassName for the CoreGroupAttributes as per issue reported here #327 

## Description

See above.

## Related Issue(s):

#327 

## Testing

The following test checks that cssClassName is availble for the CoreGroupAttributes

### Setup

If you update a page with the following HTML

```
<!-- wp:group {"tagName":"header","className":"test-group-class is-style-section-1","style":{"elements":{"link":{"color":{"text":"var:preset|color|accent-3"}}},"spacing":{"padding":{"top":"var:preset|spacing|20","bottom":"var:preset|spacing|20","left":"var:preset|spacing|20","right":"var:preset|spacing|20"},"margin":{"top":"var:preset|spacing|20","bottom":"var:preset|spacing|20"},"blockGap":"var:preset|spacing|20"},"dimensions":{"minHeight":"100px"},"border":{"radius":"1px","width":"4px"}},"backgroundColor":"base","textColor":"accent-3","borderColor":"accent-3","layout":{"type":"flex","flexWrap":"nowrap"}} -->
<header id="test-group-id" class="wp-block-group test-group-class is-style-section-1 has-border-color has-accent-3-border-color has-accent-3-color has-base-background-color has-text-color has-background has-link-color" style="border-width:4px;border-radius:1px;min-height:100px;margin-top:var(--wp--preset--spacing--20);margin-bottom:var(--wp--preset--spacing--20);padding-top:var(--wp--preset--spacing--20);padding-right:var(--wp--preset--spacing--20);padding-bottom:var(--wp--preset--spacing--20);padding-left:var(--wp--preset--spacing--20)"><!-- wp:paragraph -->
<p>This is the left paragraph.</p>
<!-- /wp:paragraph -->

<!-- wp:paragraph -->
<p>This is the right paragraph</p>
<!-- /wp:paragraph --></header>
<!-- /wp:group -->

<!-- wp:paragraph {"className":"example-class"} -->
<p class="example-class">This is an example page. It's different from a blog post because it will stay in one place and will show up in your site navigation (in most themes). Most people start with an About page that introduces them to potential site visitors. It might say something like this:</p>
<!-- /wp:paragraph -->

<!-- wp:quote -->
<blockquote class="wp-block-quote"><!-- wp:paragraph -->
<p>Hi there! I'm a bike messenger by day, aspiring actor by night, and this is my website. I live in Los Angeles, have a great dog named Jack, and I like piña coladas. (And gettin' caught in the rain.)</p>
<!-- /wp:paragraph --></blockquote>
<!-- /wp:quote -->

<!-- wp:paragraph -->
<p>...or something like this:</p>
<!-- /wp:paragraph -->

<!-- wp:quote -->
<blockquote class="wp-block-quote"><!-- wp:paragraph -->
<p>The XYZ Doohickey Company was founded in 1971, and has been providing quality doohickeys to the public ever since. Located in Gotham City, XYZ employs over 2,000 people and does all kinds of awesome things for the Gotham community.</p>
<!-- /wp:paragraph --></blockquote>
<!-- /wp:quote -->

<!-- wp:paragraph -->
<p>As a new WordPress user, you should go to <a href="https://alpha.multisite.local/wp-admin/">your dashboard</a> to delete this page and create new pages for your content. Have fun!</p>
<!-- /wp:paragraph -->
``` 

If you then run the following query in WPGraphQL IDE 

``` gql
fragment CoreGroupFragment on CoreGroup {
  attributes {
    align
    allowedBlocks
    backgroundColor
    borderColor
    className
    cssClassName
    fontFamily
    fontSize
    gradient
    layout
    lock
    metadata
    style
    tagName
    textColor
  }
}

query Page($id: ID!) {
  page(id: $id, idType: DATABASE_ID) {
    databaseId
    editorBlocks(flat:true) {
      apiVersion
      blockEditorCategoryName
      clientId
      cssClassNames
      innerBlocks {
        name
      }
      name
      parentClientId
      renderedHtml
      type
      ...CoreGroupFragment
    }
  }
}
```

Note:  Add the following query variables (replacing your page/post id)

``` json
{
  "id": 2
}
```

You should get the following response 

```json
{
  "data": {
    "page": {
      "databaseId": 2,
      "editorBlocks": [
        {
          "apiVersion": 3,
          "blockEditorCategoryName": "design",
          "clientId": "67741a2965a9b",
          "cssClassNames": [
            "test-group-class",
            "is-style-default"
          ],
          "innerBlocks": [
            {
              "name": "core/paragraph"
            },
            {
              "name": "core/paragraph"
            }
          ],
          "name": "core/group",
          "parentClientId": null,
          "renderedHtml": "\n<header id=\"test-group-id\" class=\"wp-block-group test-group-class is-style-default is-content-justification-center is-layout-flex wp-container-core-group-is-layout-1 wp-block-group-is-layout-flex\">\n<p>This is the left paragraph.</p>\n\n\n\n<p>This is the right paragraph</p>\n</header>\n",
          "type": "CoreGroup",
          "attributes": {
            "align": null,
            "allowedBlocks": null,
            "backgroundColor": null,
            "borderColor": null,
            "className": "test-group-class is-style-default",
            "cssClassName": "wp-block-group test-group-class is-style-default is-content-justification-center is-layout-flex wp-container-core-group-is-layout-7 wp-block-group-is-layout-flex",
            "fontFamily": null,
            "fontSize": null,
            "gradient": null,
            "layout": "{\"type\":\"flex\",\"flexWrap\":\"wrap\",\"justifyContent\":\"center\"}",
            "lock": null,
            "metadata": null,
            "style": null,
            "tagName": "header",
            "textColor": null
          }
        },
        {
          "apiVersion": 3,
          "blockEditorCategoryName": "text",
          "clientId": "67741a2965a9f",
          "cssClassNames": null,
          "innerBlocks": [],
          "name": "core/paragraph",
          "parentClientId": "67741a2965a9b",
          "renderedHtml": "\n<p>This is the left paragraph.</p>\n",
          "type": "CoreParagraph"
        },
        {
          "apiVersion": 3,
          "blockEditorCategoryName": "text",
          "clientId": "67741a2965aa1",
          "cssClassNames": null,
          "innerBlocks": [],
          "name": "core/paragraph",
          "parentClientId": "67741a2965a9b",
          "renderedHtml": "\n<p>This is the right paragraph</p>\n",
          "type": "CoreParagraph"
        },
        {
          "apiVersion": 3,
          "blockEditorCategoryName": "text",
          "clientId": "67741a2965aa6",
          "cssClassNames": [
            "example-class"
          ],
          "innerBlocks": [],
          "name": "core/paragraph",
          "parentClientId": null,
          "renderedHtml": "\n<p class=\"example-class\">This is an example page. It's different from a blog post because it will stay in one place and will show up in your site navigation (in most themes). Most people start with an About page that introduces them to potential site visitors. It might say something like this:</p>\n",
          "type": "CoreParagraph"
        }
      ]
    }
  }
}
```

Note that the cssClassName for the CoreGroup attribute node is `wp-block-group test-group-class is-style-default is-content-justification-center is-layout-flex wp-container-core-group-is-layout-7 wp-block-group-is-layout-flex` 

### Screenshots

<img width="1568" alt="Screenshot 2024-12-31 at 16 31 34" src="https://github.com/user-attachments/assets/360f8376-8b8d-4c0d-bdf7-16db54f493f9" />


