### PR TITLE
Feature: Added CoreListItem Block and updated CoreList block

### DIFF
--- a/.changeset/khaki-forks-prove.md
+++ b/.changeset/khaki-forks-prove.md
@@ -1,0 +1,84 @@
+---
+"@wpengine/wp-graphql-content-blocks": minor
+---
+
+Added CoreListItem block and new fields to query CoreListItem for the CoreList block.
+
+Notable changes:
+
+Added the field items which retrieves the CoreListItem child blocks for a CoreList.
+For the CoreListItem block we added children and value so that we can query values and child blocks if they are core/list-iem blcoks
+
+Example query 
+
+```gql
+query postQuery($id: ID!) {
+  post(id: $id, idType: DATABASE_ID, asPreview: false) {
+    title
+    editorBlocks(flat: false) {
+      name
+      ... on CoreList {
+        ordered
+        items {
+          value
+          children {
+            value
+            children {
+              value
+            }
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+This returns an array of items and child items for that block e.g. 
+
+```json
+{
+  "data": {
+    "post": {
+      "title": "Hello world!",
+      "editorBlocks": [
+        {
+          "name": "core/list",
+          "ordered": true,
+          "items": [
+            {
+              "value": "<li>List item 1</li>",
+              "children": []
+            },
+            {
+              "value": "<li>List item 2</li>",
+              "children": [
+                {
+                  "value": "<li>Child list item 1</li>",
+                  "children": [
+                    {
+                      "value": "<li>Third level list item</li>"
+                    }
+                  ]
+                },
+                {
+                  "value": "<li>Child list item 2</li>",
+                  "children": []
+                }
+              ]
+            },
+            {
+              "value": "<li>List item 3</li>",
+              "children": []
+            },
+            {
+              "value": "<li>List item 4</li>",
+              "children": []
+            }
+          ]
+        }
+      ]
+    }
+  },
+}
+```

--- a/includes/Blocks/CoreList.php
+++ b/includes/Blocks/CoreList.php
@@ -7,6 +7,9 @@
 
 namespace WPGraphQL\ContentBlocks\Blocks;
 
+use WPGraphQL\ContentBlocks\Registry\Registry;
+use WP_Block_Type;
+
 /**
  * Class CoreList
  */
@@ -24,4 +27,72 @@ class CoreList extends Block {
 			'attribute' => 'class',
 		],
 	];
+
+	/**
+	 * Block constructor.
+	 *
+	 * @param \WP_Block_Type                             $block The Block Type.
+	 * @param \WPGraphQL\ContentBlocks\Registry\Registry $block_registry The instance of the WPGraphQL block registry.
+	 */
+	public function __construct( WP_Block_Type $block, Registry $block_registry ) {
+		parent::__construct( $block, $block_registry );
+
+		register_graphql_field(
+			$this->type_name,
+			'ordered',
+			[
+				'type'        => 'Boolean',
+				'description' => sprintf(
+					__( 'Whether the list is ordered or unordered', 'wp-graphql-content-blocks' ),
+					$this->type_name
+				),
+				'resolve'     => static function ( $block ) {
+					return $block['attrs']['ordered'] ?? false;
+				},
+			]
+		);
+
+		register_graphql_field(
+			$this->type_name,
+			'items',
+			[
+				'type'        => [ 'list_of' => 'CoreListItem' ],
+				'description' => sprintf(
+					__( 'Whether list items', 'wp-graphql-content-blocks' ),
+					$this->type_name
+				),
+				'resolve'     => static function ( $block ) {
+					return self::resolveInnerBlocks( $block['innerBlocks'] );
+				},
+			]
+		);
+	}
+
+	/**
+	 * @param array $inner_blocks An array of inner blocks.
+	 *
+	 * @return array An array of parsed inner blocks.
+	 */
+	public static function resolveInnerBlocks( array $inner_blocks ): array {
+
+		$items = [];
+
+		foreach ( $inner_blocks as $block ) {
+			switch ( $block['blockName'] ) {
+				case 'core/list-item':
+					$items[] = [
+						'value'    => trim( $block['innerHTML'], "\n" ),
+						'children' => self::resolveInnerBlocks( $block['innerBlocks'] ),
+					];
+					break;
+
+				case 'core/list':
+					$nested_items = self::resolveInnerBlocks( $block['innerBlocks'] );
+					$items        = array_merge( $items, $nested_items );
+					break;
+			}
+		}
+
+		return $items;
+	}
 }

--- a/includes/Blocks/CoreListItem.php
+++ b/includes/Blocks/CoreListItem.php
@@ -1,0 +1,64 @@
+<?php
+/**
+ * Core List Item Block
+ *
+ * @package WPGraphQL\ContentBlocks\Blocks
+ */
+
+namespace WPGraphQL\ContentBlocks\Blocks;
+
+use WPGraphQL\ContentBlocks\Registry\Registry;
+use WP_Block_Type;
+
+/**
+ * Class CoreListItem
+ */
+class CoreListItem extends Block {
+	/**
+	 * {@inheritDoc}
+	 *
+	 * @var array|null
+	 */
+	protected ?array $additional_block_attributes = [
+		'cssClassName' => [
+			'type'      => 'string',
+			'selector'  => 'li',
+			'source'    => 'attribute',
+			'attribute' => 'class',
+		],
+	];
+
+	/**
+	 * Block constructor.
+	 *
+	 * @param \WP_Block_Type                             $block The Block Type.
+	 * @param \WPGraphQL\ContentBlocks\Registry\Registry $block_registry The instance of the WPGraphQL block registry.
+	 */
+	public function __construct( WP_Block_Type $block, Registry $block_registry ) {
+		parent::__construct( $block, $block_registry );
+
+		register_graphql_field(
+			$this->type_name,
+			'value',
+			[
+				'type'        => 'String',
+				'description' => sprintf(
+					__( 'The content of the list item', 'wp-graphql-content-blocks' ),
+					$this->type_name
+				),
+			]
+		);
+
+		register_graphql_field(
+			$this->type_name,
+			'children',
+			[
+				'type'        => [ 'list_of' => 'CoreListItem' ],
+				'description' => sprintf(
+					__( 'The content of the list item', 'wp-graphql-content-blocks' ),
+					$this->type_name
+				),
+			]
+		);
+	}
+}


### PR DESCRIPTION
# Overview

This is a solution for the issue reported #253  whereby a user might want to recursively query child blocks.

This PR has 2 main features

1. Adds a CoreListItem Block
2. Updates the CoreList Block with new fields so that you can recursively get children for the CoreListItem


# Example

You have a list with 3 levels  e.g.

<img width="1426" alt="Screenshot 2025-01-14 at 12 53 00" src="https://github.com/user-attachments/assets/39159c02-919c-4faa-9459-65ed658efe2f" />


The HTML for the block is

```
<!-- wp:list {"ordered":true} -->
<ol class="wp-block-list"><!-- wp:list-item -->
<li>List item 1</li>
<!-- /wp:list-item -->

<!-- wp:list-item -->
<li>List item 2<!-- wp:list {"className":"is-style-checkmark-list"} -->
<ul class="wp-block-list is-style-checkmark-list"><!-- wp:list-item -->
<li>Child list item 1<!-- wp:list -->
<ul class="wp-block-list"><!-- wp:list-item -->
<li>Third level list item</li>
<!-- /wp:list-item --></ul>
<!-- /wp:list --></li>
<!-- /wp:list-item -->

<!-- wp:list-item -->
<li>Child list item 2</li>
<!-- /wp:list-item --></ul>
<!-- /wp:list --></li>
<!-- /wp:list-item -->

<!-- wp:list-item -->
<li>List item 3</li>
<!-- /wp:list-item -->

<!-- wp:list-item -->
<li>List item 4</li>
<!-- /wp:list-item --></ol>
<!-- /wp:list -->
```

The following query will do the following

1. Check if the list is ordered (boolean)
2. Get an array of items (CoreListItem blocks) and get children and values for those blocks and child blocks

```gql
query postQuery($id: ID!) {
  post(id: $id, idType: DATABASE_ID, asPreview: false) {
    title
    editorBlocks(flat: false) {
      name
      ... on CoreList {
        ordered
        items {
          value
          children {
            value
            children {
              value
            }
          }
        }
      }
    }
  }
}
```

The response from WP GraphQL is


```json
{
  "data": {
    "post": {
      "title": "Hello world!",
      "editorBlocks": [
        {
          "name": "core/list",
          "ordered": true,
          "items": [
            {
              "value": "<li>List item 1</li>",
              "children": []
            },
            {
              "value": "<li>List item 2</li>",
              "children": [
                {
                  "value": "<li>Child list item 1</li>",
                  "children": [
                    {
                      "value": "<li>Third level list item</li>"
                    }
                  ]
                },
                {
                  "value": "<li>Child list item 2</li>",
                  "children": []
                }
              ]
            },
            {
              "value": "<li>List item 3</li>",
              "children": []
            },
            {
              "value": "<li>List item 4</li>",
              "children": []
            }
          ]
        }
      ]
    }
  }
}
```

This should allow developers to loop through the items key and then children keys to get the value for each list item.



<img width="1445" alt="image" src="https://github.com/user-attachments/assets/fae3e9b6-51af-4ea7-b4fd-e9b6728a1dcc" />




