### PR TITLE
Added WP GraphQL as a plugin requirement.

### DIFF
--- a/.changeset/bright-trains-approve.md
+++ b/.changeset/bright-trains-approve.md
@@ -1,0 +1,5 @@
+---
+"@wpengine/wp-graphql-content-blocks": minor
+---
+
+Added WP GraphQL as a required plugin.

--- a/readme.txt
+++ b/readme.txt
@@ -7,6 +7,7 @@ Stable tag: 4.4.0
 Requires PHP: 7.4
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
+Requires Plugins: wp-graphql
 
 Extends WPGraphQL to support querying (Gutenberg) Blocks as data.
 


### PR DESCRIPTION
See  #263

WP GraphQL is now a plugin requirement. 