### PR TITLE
Added block and content resolver for CoreFootnotes

### DIFF
--- a/.changeset/eighty-cameras-join.md
+++ b/.changeset/eighty-cameras-join.md
@@ -1,0 +1,45 @@
+---
+"@wpengine/wp-graphql-content-blocks": patch
+---
+
+Added content resolver for CoreFootnotes when the post_meta isn't loaded
+
+
+```gql
+fragment CoreFootnotesBlockFragment on CoreFootnotes {
+  innerBlocks {
+    renderedHtml
+  }
+}
+
+query Post($id: ID!) {
+  post(id: $id, idType: DATABASE_ID) {
+    databaseId
+    editorBlocks {
+      ...CoreFootnotesBlockFragment
+    }
+  }
+}
+```
+
+
+```json
+{
+  "data": {
+    "post": {
+      "databaseId": 16,
+      "editorBlocks": [
+        {},
+        {
+          "innerBlocks": [
+            {
+              "renderedHtml": "<ol class=\"footnotes\"><li id=\"d4051e5e-1547-49ff-ab6d-bec1caa6aabc\"><a href=\"https://wpengine.com/about-us/\">https://wpengine.com/about-us/</a></li><li id=\"2e79de23-68a8-42eb-87ab-1f2467a21752\"><a href=\"https://wpengine.com/support/\">https://wpengine.com/support/</a></li></ol>"
+            }
+          ]
+        },
+        {}
+      ]
+    }
+  }
+}
+```

--- a/.changeset/eighty-cameras-join.md
+++ b/.changeset/eighty-cameras-join.md
@@ -1,5 +1,5 @@
 ---
-"@wpengine/wp-graphql-content-blocks": patch
+"@wpengine/wp-graphql-content-blocks": minor
 ---
 
 Added content resolver for CoreFootnotes when the post_meta isn't loaded

--- a/includes/Blocks/CoreFootnotes.php
+++ b/includes/Blocks/CoreFootnotes.php
@@ -1,0 +1,27 @@
+<?php
+/**
+ * Core Paragraph Block
+ *
+ * @package WPGraphQL\ContentBlocks\Blocks
+ */
+
+namespace WPGraphQL\ContentBlocks\Blocks;
+
+/**
+ * Class CoreParagraph
+ */
+class CoreFootnotes extends Block {
+	/**
+	 * {@inheritDoc}
+	 *
+	 * @var array|null
+	 */
+	protected ?array $additional_block_attributes = [
+		'cssClassName' => [
+			'type'      => 'string',
+			'selector'  => 'p',
+			'source'    => 'attribute',
+			'attribute' => 'class',
+		],
+	];
+}


### PR DESCRIPTION
## Summary

This PR adds a content block for CoreFootnotes and also adds a post content resolver to load the post meta data for footnotes and also parse the HTML.

## Example


**Query**

```gql
fragment CoreFootnotesBlockFragment on CoreFootnotes {
  innerBlocks {
    renderedHtml
  }
}

query Post($id: ID!) {
  post(id: $id, idType: DATABASE_ID) {
    databaseId
    editorBlocks {
      ...CoreFootnotesBlockFragment
    }
  }
}
```

**Example Response**


```json
{
  "data": {
    "post": {
      "databaseId": 16,
      "editorBlocks": [
        {},
        {
          "innerBlocks": [
            {
              "renderedHtml": "<ol class=\"footnotes\"><li id=\"d4051e5e-1547-49ff-ab6d-bec1caa6aabc\"><a href=\"https://wpengine.com/about-us/\">https://wpengine.com/about-us/</a></li><li id=\"2e79de23-68a8-42eb-87ab-1f2467a21752\"><a href=\"https://wpengine.com/support/\">https://wpengine.com/support/</a></li></ol>"
            }
          ]
        },
        {}
      ]
    }
  },
  "extensions": {
    "debug": [],
    "queryAnalyzer": {
      "keys": "262c7066ca9adad309e85fa6e74f44cbba09adbaf24eba42ac58b418899a687f graphql:Query operation:Post cG9zdDoxNg==",
      "keysLength": 106,
      "keysCount": 4,
      "skippedKeys": "",
      "skippedKeysSize": 0,
      "skippedKeysCount": 0,
      "skippedTypes": []
    }
  }
}
```
