### PR TITLE
feat: Adds property typing for an object attribute

### DIFF
--- a/.changeset/brave-dragons-laugh.md
+++ b/.changeset/brave-dragons-laugh.md
@@ -1,0 +1,58 @@
+---
+"@wpengine/wp-graphql-content-blocks": minor
+---
+
+Adds support for specifying typed and queryable properties for object attributes in block.json.
+
+Example: Defining a Typed Object in `block.json`:
+
+```json
+"attributes": {
+  "film": {
+    "type": "object",
+    "default": {
+      "id": 0,
+      "title": "Film Title",
+      "director": "Director Name",
+      "__typed": {
+        "id": "integer",
+        "title": "string",
+        "director": "string",
+        "year": "string"
+      }
+    }
+  }
+}
+```
+
+In this example, the `film` attribute is an object with defined types for each property (`id`, `title`, `director`, and optionally `year`).
+
+Querying Object Properties in GraphQL:
+
+
+```graphql
+fragment Film on MyPluginFilmBlock {
+    attributes {
+        film {
+            id,
+            title,
+            director,
+            year
+        }
+    },
+}
+
+query GetAllPostsWhichSupportBlockEditor {
+    posts {
+        edges {
+            node {
+                editorBlocks {
+                    __typename
+                    name
+                    ...Film
+                }
+            }
+        }
+    }
+}
+```

--- a/README.md
+++ b/README.md
@@ -86,6 +86,64 @@ If the resolved block has values for those fields, it will return them, otherwis
 }
 ```
 
+## Querying Object Types with Typed Properties
+
+You can now query object-type block attributes with each property, provided the `__typed` structure is defined in the block's JSON configuration. 
+This allows you to query individual properties of the object for finer control and enhanced usability.
+
+Example: Defining a Typed Object in `block.json`:
+
+```json
+"attributes": {
+  "film": {
+    "type": "object",
+    "default": {
+      "id": 0,
+      "title": "Film Title",
+      "director": "Director Name",
+      "__typed": {
+        "id": "integer",
+        "title": "string",
+        "director": "string",
+        "year": "string"
+      }
+    }
+  }
+}
+```
+
+In this example, the `film` attribute is an object with defined types for each property (`id`, `title`, `director`, and optionally `year`).
+
+Querying Object Properties in GraphQL:
+
+
+```graphql
+fragment Film on MyPluginFilmBlock {
+    attributes {
+        film {
+            id,
+            title,
+            director,
+            year
+        }
+    },
+}
+
+query GetAllPostsWhichSupportBlockEditor {
+    posts {
+        edges {
+            node {
+                editorBlocks {
+                    __typename
+                    name
+                    ...Film
+                }
+            }
+        }
+    }
+}
+```
+
 ## What about innerBlocks?
 
 In order to facilitate querying `innerBlocks` fields more efficiently you want to use `editorBlocks(flat: true)` instead of `editorBlocks`.

--- a/includes/Blocks/Block.php
+++ b/includes/Blocks/Block.php
@@ -165,7 +165,7 @@ class Block {
 					$of_type = $this->get_attribute_type( $name, $attribute['items'], $prefix );
 				}
 
-				$type = null !== $of_type ? [ 'list_of' => $of_type ] : Scalar::ATTRIBUTES_ARRAY_TYPE_NAME;
+				$type = null !== $of_type ? [ 'list_of' => $of_type ] : Scalar::get_block_attributes_array_type_name();
 				break;
 			case 'object':
 				// Proceed with the typed object if typing provided, otherwise continue with scalar object.
@@ -174,7 +174,7 @@ class Block {
 					$typed = $this->build_typed_object_config( $attribute['default'] );
 				}
 
-				$type = $typed ? $this->create_and_register_inner_object_type( $name, $typed, $prefix ) : Scalar::ATTRIBUTES_OBJECT_TYPE_NAME;
+				$type = $typed ? $this->create_and_register_inner_object_type( $name, $typed, $prefix ) : Scalar::get_block_attributes_object_type_name();
 				break;
 		}
 

--- a/includes/Blocks/Block.php
+++ b/includes/Blocks/Block.php
@@ -163,10 +163,10 @@ class Block {
 					$of_type = $this->get_attribute_type( $name, $attribute['items'], $prefix );
 				}
 
-				$type = null !== $of_type ? [ 'list_of' => $of_type ] : Scalar::get_block_attributes_array_type_name();
+				$type = null !== $of_type ? [ 'list_of' => $of_type ] : Scalar::ATTRIBUTES_ARRAY_TYPE_NAME;
 				break;
 			case 'object':
-				$type = Scalar::get_block_attributes_object_type_name();
+				$type = Scalar::ATTRIBUTES_OBJECT_TYPE_NAME;
 				break;
 		}
 

--- a/includes/Blocks/Block.php
+++ b/includes/Blocks/Block.php
@@ -91,14 +91,14 @@ class Block {
 			return;
 		}
 
-		$block_attribute_fields = $this->get_block_attribute_fields( $block_attributes, $this->type_name . 'Attributes' );
+		$block_attribute_type_name = $this->type_name . 'Attributes';
+		$block_attribute_fields    = $this->get_block_attribute_fields( $block_attributes, $block_attribute_type_name );
 
 		if ( empty( $block_attribute_fields ) ) {
 			return;
 		}
 
 		// For each attribute, register a new object type and attach it to the block type as a field
-		$block_attribute_type_name = $this->type_name . 'Attributes';
 		register_graphql_object_type(
 			$block_attribute_type_name,
 			[

--- a/includes/Blocks/Block.php
+++ b/includes/Blocks/Block.php
@@ -162,7 +162,10 @@ class Block {
 			case 'array':
 				if ( isset( $attribute['query'] ) ) {
 					$type = [ 'list_of' => $this->get_query_type( $name, $attribute['query'], $prefix ) ];
-				} elseif ( isset( $attribute['items'] ) ) {
+					break;
+				}
+
+				if ( isset( $attribute['items'] ) ) {
 					$of_type = $this->get_attribute_type( $name, $attribute['items'], $prefix );
 
 					if ( null !== $of_type ) {
@@ -170,9 +173,10 @@ class Block {
 					} else {
 						$type = Scalar::get_block_attributes_array_type_name();
 					}
-				} else {
-					$type = Scalar::get_block_attributes_array_type_name();
+					break;
 				}
+
+				$type = Scalar::get_block_attributes_array_type_name();
 				break;
 			case 'object':
 				$type = Scalar::get_block_attributes_object_type_name();

--- a/includes/Blocks/Block.php
+++ b/includes/Blocks/Block.php
@@ -42,16 +42,16 @@ class Block {
 	/**
 	 * The attributes of the block.
 	 *
-	 * @var array|null
+	 * @var array
 	 */
-	protected ?array $block_attributes;
+	protected array $block_attributes = [];
 
 	/**
 	 * Any Additional attributes of the block not defined in block.json.
 	 *
-	 * @var array|null
+	 * @var array
 	 */
-	protected ?array $additional_block_attributes;
+	protected array $additional_block_attributes = [];
 
 	/**
 	 * Block constructor.
@@ -62,7 +62,7 @@ class Block {
 	public function __construct( WP_Block_Type $block, Registry $block_registry ) {
 		$this->block            = $block;
 		$this->block_registry   = $block_registry;
-		$this->block_attributes = array_merge( $this->block->attributes ?? [], $this->additional_block_attributes ?? [] );
+		$this->block_attributes = array_merge( $this->block->attributes ?? [], $this->additional_block_attributes );
 		$this->type_name        = WPGraphQLHelpers::format_type_name( $block->name );
 		$this->register_block_type();
 	}

--- a/includes/Blocks/Block.php
+++ b/includes/Blocks/Block.php
@@ -176,9 +176,7 @@ class Block {
 		}
 
 		if ( null !== $type ) {
-			$default_value = $attribute['default'] ?? null;
-
-			if ( isset( $default_value ) ) {
+			if ( isset( $attribute['default'] ) ) {
 				$type = [ 'non_null' => $type ];
 			}
 		}

--- a/includes/Blocks/Block.php
+++ b/includes/Blocks/Block.php
@@ -154,7 +154,7 @@ class Block {
 				break;
 			case 'array':
 				if ( isset( $attribute['query'] ) ) {
-					$type = [ 'list_of' => $this->get_query_type( $name, $attribute['query'], $prefix ) ];
+					$type = [ 'list_of' => $this->create_and_register_inner_object_type( $name, $attribute['query'], $prefix ) ];
 					break;
 				}
 
@@ -215,23 +215,22 @@ class Block {
 	}
 
 	/**
-	 * Returns the type of the block query attribute
+	 * Dynamically creates and registers a GraphQL object type for queries or typed object attributes.
 	 *
-	 * @param string $name The block name
-	 * @param array  $query The block query config
-	 * @param string $prefix The current prefix string to use for registering the new query attribute type
+	 * @param string $name The block name.
+	 * @param array  $config The block config.
+	 * @param string $prefix The current prefix string to use for registering the new attribute type.
 	 */
-	private function get_query_type( string $name, array $query, string $prefix ): string {
-		$type = $prefix . ucfirst( $name );
-
-		$fields = $this->create_attributes_fields( $query, $type );
+	private function create_and_register_inner_object_type( string $name, array $config, string $prefix ): string {
+		$type   = $prefix . ucfirst( $name );
+		$fields = $this->create_attributes_fields( $config, $type );
 
 		register_graphql_object_type(
 			$type,
 			[
 				'fields'      => $fields,
 				'description' => sprintf(
-					// translators: %1$s is the attribute name, %2$s is the block attributes field.
+				// translators: %1$s is the attribute name, %2$s is the block attributes field.
 					__( 'The "%1$s" field on the "%2$s" block attribute field', 'wp-graphql-content-blocks' ),
 					$type,
 					$prefix
@@ -243,10 +242,10 @@ class Block {
 	}
 
 	/**
-	 * Creates the new attribute fields for query types
+	 * Creates the new attribute fields for inner block types.
 	 *
-	 * @param array  $attributes The query attributes config
-	 * @param string $prefix The current prefix string to use for registering the new query attribute type
+	 * @param array  $attributes The attributes config.
+	 * @param string $prefix The current prefix string to use for registering the new inner block attribute type.
 	 */
 	private function create_attributes_fields( $attributes, $prefix ): array {
 		$fields = [];

--- a/includes/Blocks/Block.php
+++ b/includes/Blocks/Block.php
@@ -165,18 +165,12 @@ class Block {
 					break;
 				}
 
+				$of_type = null;
 				if ( isset( $attribute['items'] ) ) {
 					$of_type = $this->get_attribute_type( $name, $attribute['items'], $prefix );
-
-					if ( null !== $of_type ) {
-						$type = [ 'list_of' => $of_type ];
-					} else {
-						$type = Scalar::get_block_attributes_array_type_name();
-					}
-					break;
 				}
 
-				$type = Scalar::get_block_attributes_array_type_name();
+				$type = null !== $of_type ? [ 'list_of' => $of_type ] : Scalar::get_block_attributes_array_type_name();
 				break;
 			case 'object':
 				$type = Scalar::get_block_attributes_object_type_name();

--- a/includes/Blocks/Block.php
+++ b/includes/Blocks/Block.php
@@ -87,9 +87,12 @@ class Block {
 			$this->additional_block_attributes ?? [],
 		);
 
+		if ( empty( $block_attributes ) ) {
+			return;
+		}
+
 		$block_attribute_fields = $this->get_block_attribute_fields( $block_attributes, $this->type_name . 'Attributes' );
 
-		// Bail early if no attributes are defined.
 		if ( empty( $block_attribute_fields ) ) {
 			return;
 		}
@@ -187,15 +190,10 @@ class Block {
 	/**
 	 * Gets the WPGraphQL field registration config for the block attributes.
 	 *
-	 * @param ?array $block_attributes The block attributes.
+	 * @param array  $block_attributes The block attributes.
 	 * @param string $prefix The current prefix string to use for the get_query_type
 	 */
-	private function get_block_attribute_fields( ?array $block_attributes, string $prefix = '' ): array {
-		// Bail early if no attributes are defined.
-		if ( null === $block_attributes ) {
-			return [];
-		}
-
+	private function get_block_attribute_fields( array $block_attributes, string $prefix = '' ): array {
 		$fields = [];
 		foreach ( $block_attributes as $attribute_name => $attribute_config ) {
 			$graphql_type = $this->get_attribute_type( $attribute_name, $attribute_config, $prefix );
@@ -222,7 +220,7 @@ class Block {
 					return $result[ $attribute_name ];
 				},
 			];
-		}//end foreach
+		}
 
 		return $fields;
 	}

--- a/includes/Blocks/Block.php
+++ b/includes/Blocks/Block.php
@@ -137,42 +137,46 @@ class Block {
 	private function get_attribute_type( $name, $attribute, $prefix ) {
 		$type = null;
 
-		if ( isset( $attribute['type'] ) ) {
-			switch ( $attribute['type'] ) {
-				case 'rich-text':
-				case 'string':
-					$type = 'String';
-					break;
-				case 'boolean':
-					$type = 'Boolean';
-					break;
-				case 'number':
-					$type = 'Float';
-					break;
-				case 'integer':
-					$type = 'Int';
-					break;
-				case 'array':
-					if ( isset( $attribute['query'] ) ) {
-						$type = [ 'list_of' => $this->get_query_type( $name, $attribute['query'], $prefix ) ];
-					} elseif ( isset( $attribute['items'] ) ) {
-						$of_type = $this->get_attribute_type( $name, $attribute['items'], $prefix );
+		if ( ! isset( $attribute['type'] ) ) {
+			if ( ! isset( $attribute['source'] ) ) {
+				return null;
+			}
 
-						if ( null !== $of_type ) {
-							$type = [ 'list_of' => $of_type ];
-						} else {
-							$type = Scalar::get_block_attributes_array_type_name();
-						}
+			$type = 'String';
+		}
+
+		switch ( $attribute['type'] ) {
+			case 'rich-text':
+			case 'string':
+				$type = 'String';
+				break;
+			case 'boolean':
+				$type = 'Boolean';
+				break;
+			case 'number':
+				$type = 'Float';
+				break;
+			case 'integer':
+				$type = 'Int';
+				break;
+			case 'array':
+				if ( isset( $attribute['query'] ) ) {
+					$type = [ 'list_of' => $this->get_query_type( $name, $attribute['query'], $prefix ) ];
+				} elseif ( isset( $attribute['items'] ) ) {
+					$of_type = $this->get_attribute_type( $name, $attribute['items'], $prefix );
+
+					if ( null !== $of_type ) {
+						$type = [ 'list_of' => $of_type ];
 					} else {
 						$type = Scalar::get_block_attributes_array_type_name();
 					}
-					break;
-				case 'object':
-					$type = Scalar::get_block_attributes_object_type_name();
-					break;
-			}
-		} elseif ( isset( $attribute['source'] ) ) {
-			$type = 'String';
+				} else {
+					$type = Scalar::get_block_attributes_array_type_name();
+				}
+				break;
+			case 'object':
+				$type = Scalar::get_block_attributes_object_type_name();
+				break;
 		}
 
 		if ( null !== $type && isset( $attribute['default'] ) ) {

--- a/includes/Blocks/Block.php
+++ b/includes/Blocks/Block.php
@@ -119,7 +119,7 @@ class Block {
 	}
 
 	/**
-	 * Returns the type of the block attribute
+	 * Returns the type of the block attribute.
 	 *
 	 * @param string              $name The block name
 	 * @param array<string,mixed> $attribute The block attribute config
@@ -132,10 +132,10 @@ class Block {
 
 		if ( ! isset( $attribute['type'] ) ) {
 			if ( ! isset( $attribute['source'] ) ) {
-				return null;
+				return null; // No type or source defined, return null.
 			}
 
-			$type = 'String';
+			$type = 'String'; // Default to String if only 'source' is defined.
 		}
 
 		switch ( $attribute['type'] ) {

--- a/includes/Blocks/Block.php
+++ b/includes/Blocks/Block.php
@@ -175,10 +175,8 @@ class Block {
 			$type = 'String';
 		}
 
-		if ( null !== $type ) {
-			if ( isset( $attribute['default'] ) ) {
-				$type = [ 'non_null' => $type ];
-			}
+		if ( null !== $type && isset( $attribute['default'] ) ) {
+			$type = [ 'non_null' => $type ];
 		}
 
 		return $type;

--- a/includes/Blocks/CoreButton.php
+++ b/includes/Blocks/CoreButton.php
@@ -14,9 +14,9 @@ class CoreButton extends Block {
 	/**
 	 * {@inheritDoc}
 	 *
-	 * @var array|null
+	 * @var array
 	 */
-	protected ?array $additional_block_attributes = [
+	protected array $additional_block_attributes = [
 		'cssClassName'  => [
 			'type'      => 'string',
 			'selector'  => 'div',

--- a/includes/Blocks/CoreButtons.php
+++ b/includes/Blocks/CoreButtons.php
@@ -14,9 +14,9 @@ class CoreButtons extends Block {
 	/**
 	 * {@inheritDoc}
 	 *
-	 * @var array|null
+	 * @var array
 	 */
-	protected ?array $additional_block_attributes = [
+	protected array $additional_block_attributes = [
 		'cssClassName' => [
 			'type'      => 'string',
 			'selector'  => 'div',

--- a/includes/Blocks/CoreCode.php
+++ b/includes/Blocks/CoreCode.php
@@ -14,9 +14,9 @@ class CoreCode extends Block {
 	/**
 	 * {@inheritDoc}
 	 *
-	 * @var array|null
+	 * @var array
 	 */
-	protected ?array $additional_block_attributes = [
+	protected array $additional_block_attributes = [
 		'cssClassName' => [
 			'type'      => 'string',
 			'selector'  => 'pre',

--- a/includes/Blocks/CoreColumn.php
+++ b/includes/Blocks/CoreColumn.php
@@ -14,9 +14,9 @@ class CoreColumn extends Block {
 	/**
 	 * {@inheritDoc}
 	 *
-	 * @var array|null
+	 * @var array
 	 */
-	protected ?array $additional_block_attributes = [
+	protected array $additional_block_attributes = [
 		'cssClassName' => [
 			'type'      => 'string',
 			'selector'  => 'div',

--- a/includes/Blocks/CoreColumns.php
+++ b/includes/Blocks/CoreColumns.php
@@ -14,9 +14,9 @@ class CoreColumns extends Block {
 	/**
 	 * {@inheritDoc}
 	 *
-	 * @var array|null
+	 * @var array
 	 */
-	protected ?array $additional_block_attributes = [
+	protected array $additional_block_attributes = [
 		'cssClassName' => [
 			'type'      => 'string',
 			'selector'  => 'div',

--- a/includes/Blocks/CoreGroup.php
+++ b/includes/Blocks/CoreGroup.php
@@ -16,9 +16,9 @@ class CoreGroup extends Block {
 	 *
 	 * Note that no selector is set as it can be a variety of selectors
 	 *
-	 * @var array|null
+	 * @var array
 	 */
-	protected ?array $additional_block_attributes = [
+	protected array $additional_block_attributes = [
 		'cssClassName' => [
 			'type'      => 'string',
 			'source'    => 'attribute',

--- a/includes/Blocks/CoreHeading.php
+++ b/includes/Blocks/CoreHeading.php
@@ -14,9 +14,9 @@ class CoreHeading extends Block {
 	/**
 	 * {@inheritDoc}
 	 *
-	 * @var array|null
+	 * @var array
 	 */
-	protected ?array $additional_block_attributes = [
+	protected array $additional_block_attributes = [
 		'cssClassName' => [
 			'type'      => 'string',
 			'selector'  => 'h1, h2, h3, h4, h5, h6',

--- a/includes/Blocks/CoreImage.php
+++ b/includes/Blocks/CoreImage.php
@@ -17,9 +17,9 @@ class CoreImage extends Block {
 	/**
 	 * {@inheritDoc}
 	 *
-	 * @var array|null
+	 * @var array
 	 */
-	protected ?array $additional_block_attributes = [
+	protected array $additional_block_attributes = [
 		'cssClassName' => [
 			'type'      => 'string',
 			'selector'  => 'figure',

--- a/includes/Blocks/CoreList.php
+++ b/includes/Blocks/CoreList.php
@@ -14,9 +14,9 @@ class CoreList extends Block {
 	/**
 	 * {@inheritDoc}
 	 *
-	 * @var array|null
+	 * @var array
 	 */
-	protected ?array $additional_block_attributes = [
+	protected array $additional_block_attributes = [
 		'cssClassName' => [
 			'type'      => 'string',
 			'selector'  => 'ul,ol',

--- a/includes/Blocks/CoreParagraph.php
+++ b/includes/Blocks/CoreParagraph.php
@@ -14,9 +14,9 @@ class CoreParagraph extends Block {
 	/**
 	 * {@inheritDoc}
 	 *
-	 * @var array|null
+	 * @var array
 	 */
-	protected ?array $additional_block_attributes = [
+	protected array $additional_block_attributes = [
 		'cssClassName' => [
 			'type'      => 'string',
 			'selector'  => 'p',

--- a/includes/Blocks/CoreQuote.php
+++ b/includes/Blocks/CoreQuote.php
@@ -14,9 +14,9 @@ class CoreQuote extends Block {
 	/**
 	 * {@inheritDoc}
 	 *
-	 * @var array|null
+	 * @var array
 	 */
-	protected ?array $additional_block_attributes = [
+	protected array $additional_block_attributes = [
 		'cssClassName' => [
 			'type'      => 'string',
 			'selector'  => 'blockquote',

--- a/includes/Blocks/CoreSeparator.php
+++ b/includes/Blocks/CoreSeparator.php
@@ -14,9 +14,9 @@ class CoreSeparator extends Block {
 	/**
 	 * {@inheritDoc}
 	 *
-	 * @var array|null
+	 * @var array
 	 */
-	protected ?array $additional_block_attributes = [
+	protected array $additional_block_attributes = [
 		'cssClassName' => [
 			'type'      => 'string',
 			'selector'  => 'hr',

--- a/includes/Type/Scalar/Scalar.php
+++ b/includes/Type/Scalar/Scalar.php
@@ -16,7 +16,7 @@ final class Scalar {
 	 */
 	public function init(): void {
 		register_graphql_scalar(
-			'BlockAttributesObject',
+			self::get_block_attributes_object_type_name(),
 			[
 				'description' => __( 'Generic Object Scalar Type', 'wp-graphql-content-blocks' ),
 				'serialize'   => static function ( $value ) {
@@ -25,7 +25,7 @@ final class Scalar {
 			]
 		);
 		register_graphql_scalar(
-			'BlockAttributesArray',
+			self::get_block_attributes_array_type_name(),
 			[
 				'description' => __( 'Generic Array Scalar Type', 'wp-graphql-content-blocks' ),
 				'serialize'   => static function ( $value ) {

--- a/includes/Type/Scalar/Scalar.php
+++ b/includes/Type/Scalar/Scalar.php
@@ -12,40 +12,32 @@ namespace WPGraphQL\ContentBlocks\Type\Scalar;
  */
 final class Scalar {
 	/**
+	 * Type name of BlockAttributesArray.
+	 */
+	public const ATTRIBUTES_ARRAY_TYPE_NAME = 'BlockAttributesArray';
+
+	/**
+	 * Type name of BlockAttributesObject.
+	 */
+	public const ATTRIBUTES_OBJECT_TYPE_NAME = 'BlockAttributesObject';
+
+	/**
 	 * Scalar init procedure.
 	 */
 	public function init(): void {
-		register_graphql_scalar(
-			self::get_block_attributes_object_type_name(),
-			[
-				'description' => __( 'Generic Object Scalar Type', 'wp-graphql-content-blocks' ),
-				'serialize'   => static function ( $value ) {
-					return wp_json_encode( $value );
-				},
-			]
-		);
-		register_graphql_scalar(
-			self::get_block_attributes_array_type_name(),
-			[
-				'description' => __( 'Generic Array Scalar Type', 'wp-graphql-content-blocks' ),
-				'serialize'   => static function ( $value ) {
-					return wp_json_encode( $value );
-				},
-			]
-		);
-	}
-
-	/**
-	 * Return type name of BlockAttributesObject.
-	 */
-	public static function get_block_attributes_object_type_name(): string {
-		return 'BlockAttributesObject';
-	}
-
-	/**
-	 * Return type name of BlockAttributesArray.
-	 */
-	public static function get_block_attributes_array_type_name(): string {
-		return 'BlockAttributesArray';
+		foreach ( [
+			self::ATTRIBUTES_ARRAY_TYPE_NAME  => __( 'Generic Array Scalar Type', 'wp-graphql-content-blocks' ),
+			self::ATTRIBUTES_OBJECT_TYPE_NAME => __( 'Generic Object Scalar Type', 'wp-graphql-content-blocks' ),
+		] as $item => $description ) {
+			register_graphql_scalar(
+				$item,
+				[
+					'description' => $description,
+					'serialize'   => static function ( $value ) {
+						return wp_json_encode( $value );
+					},
+				]
+			);
+		}
 	}
 }

--- a/includes/Type/Scalar/Scalar.php
+++ b/includes/Type/Scalar/Scalar.php
@@ -12,32 +12,40 @@ namespace WPGraphQL\ContentBlocks\Type\Scalar;
  */
 final class Scalar {
 	/**
-	 * Type name of BlockAttributesArray.
-	 */
-	public const ATTRIBUTES_ARRAY_TYPE_NAME = 'BlockAttributesArray';
-
-	/**
-	 * Type name of BlockAttributesObject.
-	 */
-	public const ATTRIBUTES_OBJECT_TYPE_NAME = 'BlockAttributesObject';
-
-	/**
 	 * Scalar init procedure.
 	 */
 	public function init(): void {
-		foreach ( [
-			self::ATTRIBUTES_ARRAY_TYPE_NAME  => __( 'Generic Array Scalar Type', 'wp-graphql-content-blocks' ),
-			self::ATTRIBUTES_OBJECT_TYPE_NAME => __( 'Generic Object Scalar Type', 'wp-graphql-content-blocks' ),
-		] as $item => $description ) {
-			register_graphql_scalar(
-				$item,
-				[
-					'description' => $description,
-					'serialize'   => static function ( $value ) {
-						return wp_json_encode( $value );
-					},
-				]
-			);
-		}
+		register_graphql_scalar(
+			'BlockAttributesObject',
+			[
+				'description' => __( 'Generic Object Scalar Type', 'wp-graphql-content-blocks' ),
+				'serialize'   => static function ( $value ) {
+					return wp_json_encode( $value );
+				},
+			]
+		);
+		register_graphql_scalar(
+			'BlockAttributesArray',
+			[
+				'description' => __( 'Generic Array Scalar Type', 'wp-graphql-content-blocks' ),
+				'serialize'   => static function ( $value ) {
+					return wp_json_encode( $value );
+				},
+			]
+		);
+	}
+
+	/**
+	 * Return type name of BlockAttributesObject.
+	 */
+	public static function get_block_attributes_object_type_name(): string {
+		return 'BlockAttributesObject';
+	}
+
+	/**
+	 * Return type name of BlockAttributesArray.
+	 */
+	public static function get_block_attributes_array_type_name(): string {
+		return 'BlockAttributesArray';
 	}
 }


### PR DESCRIPTION
### Description

This PR introduces _refactoring and enhancements_ and the _functionality for creating typed attribute objects_ by specifying in block.json.

---

### Changes to `Block.php` and Child Classes
- **Constructor Refactoring**:  
  - Merged `block_attributes` directly in the constructor.  
  - Changed the type of `$block_attributes` and `$additional_block_attributes` from `array|null` to `array`, defaulting to an empty array.
- **Property Optimization**:  
  - Removed the `$block_attributes` parameter from the `get_block_attribute_fields` method in favor of the `block_attributes` property defined in the constructor.
- **Method Renaming**:  
  - Renamed `get_query_type` to `create_and_register_inner_object_type`, reflecting its broader functionality.

---
    
### Object Attribute Typing
 - Added support for specifying typing in `block.json` for object attributes. Example:
    ```json
    "attributes": {
      "film": {
        "type": "object",
        "default": {
          "id": 0,
          "title": "Film Title",
          "director": "Director Name",
          "missing": "Make sure to define in typed" // This item will not be processed, due to it is missing from typed record.
          "__typed": {
            "id": "integer",
            "title": "string",
            "director": "string",
            "year": "string", // We can provide more items without actually providing default values.
            "somethingelse": "string" // We can provide more items without actually providing default values.
          }
        }
      }
    }
    ```
Refer to the updated [README.md](https://github.com/wpengine/wp-graphql-content-blocks/pull/336/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5) for details on the new functionality.


### Readme instructions update
 - Refer to the updated [README.md](https://github.com/wpengine/wp-graphql-content-blocks/pull/336/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5).