### PR TITLE
feat: Adds property typing for an object attribute 

### DIFF
--- a/.changeset/thirty-knives-know.md
+++ b/.changeset/thirty-knives-know.md
@@ -1,0 +1,144 @@
+---
+"@wpengine/wp-graphql-content-blocks": minor
+---
+
+# Querying Object-Type Block Attributes in WPGraphQL
+
+## Overview
+With this update, you can now query object-type block attributes with each property individually, provided that the **typed structure** is defined in the class `typed_object_attributes` property or through a **WordPress filter**.
+
+## How It Works
+The `typed_object_attributes` is a **filterable** array that defines the expected **typed structure** for object-type block attributes.
+
+- The **keys** in `typed_object_attributes` correspond to **object attribute names** in the block.
+- Each value is an **associative array**, where:
+    - The key represents the **property name** inside the object.
+    - The value defines the **WPGraphQL type** (e.g., `string`, `integer`, `object`, etc.).
+- If a block attribute has a specified **typed structure**, only the properties listed within it will be processed.
+
+## Defining Typed Object Attributes
+Typed object attributes can be **defined in two ways**:
+
+### 1. In a Child Class (`typed_object_attributes` property)
+Developers can extend the `Block` class and specify **typed properties** directly:
+
+```php
+class CustomMovieBlock extends Block {
+	/**
+	 * {@inheritDoc}
+	 *
+	 * @var array<string, array<string, "array"|"boolean"|"number"|"integer"|"object"|"rich-text"|"string">>
+	 */
+	protected array $typed_object_attributes = [
+		'film' => [
+			'id'         => 'integer',
+			'title'      => 'string',
+			'director'   => 'string',
+			'soundtrack' => 'object',
+		],
+		'soundtrack' => [
+			'title'  => 'string',
+			'artist' => 'string'
+		],
+	];
+}
+```
+
+### 2. Via WordPress Filter
+You can also define **typed structures dynamically** using a WordPress filter.
+
+```php
+add_filter(
+    'wpgraphql_content_blocks_object_typing_my-custom-plugin_movie-block',
+    function () {
+        return [
+            'film'       => [
+                'id'         => 'integer',
+                'title'      => 'string',
+                'director'   => 'string',
+                'soundtrack' => 'object',
+            ],
+            'soundtrack' => [
+                'title'  => 'string',
+                'artist' => 'string'
+            ],
+        ];
+    }
+);
+```
+
+## Filter Naming Convention
+To apply custom typing via a filter, use the following format:
+
+```
+wpgraphql_content_blocks_object_typing_{block-name}
+```
+- Replace `/` in the block name with `-`.
+- Example:
+    - **Block name**: `my-custom-plugin/movie-block`
+    - **Filter name**: `wpgraphql_content_blocks_object_typing_my-custom-plugin_movie-block`
+
+## Example:
+
+
+### Example `block.json` Definition
+If the block has attributes defined as **objects**, like this:
+
+```json
+"attributes": {
+    "film": {
+      "type": "object",
+      "default": {
+        "id": 1,
+        "title": "The Matrix",
+        "director": "Director Name"
+      }
+    },
+    "soundtrack": {
+      "type": "object",
+      "default": {
+        "title": "The Matrix Revolutions...",
+        "artist": "Artist Name"
+      }
+    }
+}
+```
+This means:
+- The `film` attribute contains `id`, `title`, `director`.
+- The `soundtrack` attribute contains `title` and `artist`.
+
+## WPGraphQL Query Example
+Once the typed object attributes are **defined**, you can query them **individually** in WPGraphQL.
+
+```graphql
+fragment Movie on MyCustomPluginMovieBlock {
+    attributes {
+        film {
+            id
+            title
+            director
+            soundtrack {
+                title
+            }
+        }
+        soundtrack {
+            title
+            artist
+        }
+    }
+}
+
+query GetAllPostsWhichSupportBlockEditor {
+    posts {
+        edges {
+            node {
+                editorBlocks {
+                    __typename
+                    name
+                    ...Movie
+                }
+            }
+        }
+    }
+}
+```

--- a/README.md
+++ b/README.md
@@ -146,6 +146,150 @@ So in order to put everything back in the Headless site, you want to use the `fl
 
 > Currently the `clientId` field is only unique per request and is not persisted anywhere. If you perform another request each block will be assigned a new `clientId` each time.
 
+---
+
+## Querying Object-Type Block Attributes in WPGraphQL
+
+### Overview
+With this update, you can now query object-type block attributes with each property individually, provided that the **typed structure** is defined in the class `typed_object_attributes` property or through a **WordPress filter**.
+
+### How It Works
+The `typed_object_attributes` is a **filterable** array that defines the expected **typed structure** for object-type block attributes.
+
+- The **keys** in `typed_object_attributes` correspond to **object attribute names** in the block.
+- Each value is an **associative array**, where:
+    - The key represents the **property name** inside the object.
+    - The value defines the **WPGraphQL type** (e.g., `string`, `integer`, `object`, etc.).
+- If a block attribute has a specified **typed structure**, only the properties listed within it will be processed.
+
+### Defining Typed Object Attributes
+Typed object attributes can be **defined in two ways**:
+
+#### 1. In a Child Class (`typed_object_attributes` property)
+Developers can extend the `Block` class and specify **typed properties** directly:
+
+```php
+class CustomMovieBlock extends Block {
+	/**
+	 * {@inheritDoc}
+	 *
+	 * @var array<string, array<string, "array"|"boolean"|"number"|"integer"|"object"|"rich-text"|"string">>
+	 */
+	protected array $typed_object_attributes = [
+		'film' => [
+			'id'         => 'integer',
+			'title'      => 'string',
+			'director'   => 'string',
+			'soundtrack' => 'object',
+		],
+		'soundtrack' => [
+			'title'  => 'string',
+			'artist' => 'string'
+		],
+	];
+}
+```
+
+#### 2. Via WordPress Filter
+You can also define **typed structures dynamically** using a WordPress filter.
+
+```php
+add_filter(
+    'wpgraphql_content_blocks_object_typing_my-custom-plugin_movie-block',
+    function () {
+        return [
+            'film'       => [
+                'id'         => 'integer',
+                'title'      => 'string',
+                'director'   => 'string',
+                'soundtrack' => 'object',
+            ],
+            'soundtrack' => [
+                'title'  => 'string',
+                'artist' => 'string'
+            ],
+        ];
+    }
+);
+```
+
+### Filter Naming Convention
+To apply custom typing via a filter, use the following format:
+
+```
+wpgraphql_content_blocks_object_typing_{block-name}
+```
+- Replace `/` in the block name with `-`.
+- Example:
+    - **Block name**: `my-custom-plugin/movie-block`
+    - **Filter name**: `wpgraphql_content_blocks_object_typing_my-custom-plugin_movie-block`
+
+### Example:
+
+
+#### Example `block.json` Definition
+If the block has attributes defined as **objects**, like this:
+
+```json
+"attributes": {
+    "film": {
+      "type": "object",
+      "default": {
+        "id": 1,
+        "title": "The Matrix",
+        "director": "Director Name"
+      }
+    },
+    "soundtrack": {
+      "type": "object",
+      "default": {
+        "title": "The Matrix Revolutions...",
+        "artist": "Artist Name"
+      }
+    }
+}
+```
+This means:
+- The `film` attribute contains `id`, `title`, `director`.
+- The `soundtrack` attribute contains `title` and `artist`.
+
+### WPGraphQL Query Example
+Once the typed object attributes are **defined**, you can query them **individually** in WPGraphQL.
+
+```graphql
+fragment Movie on MyCustomPluginMovieBlock {
+    attributes {
+        film {
+            id
+            title
+            director
+            soundtrack {
+                title
+            }
+        }
+        soundtrack {
+            title
+            artist
+        }
+    }
+}
+
+query GetAllPostsWhichSupportBlockEditor {
+    posts {
+        edges {
+            node {
+                editorBlocks {
+                    __typename
+                    name
+                    ...Movie
+                }
+            }
+        }
+    }
+}
+```
+---
+
 ### Contributor License Agreement
 
 All external contributors to WP Engine products must have a signed Contributor License Agreement (CLA) in place before the contribution may be accepted into any WP Engine codebase.

--- a/includes/Blocks/Block.php
+++ b/includes/Blocks/Block.php
@@ -154,7 +154,7 @@ class Block {
 					break;
 				case 'array':
 					if ( isset( $attribute['query'] ) ) {
-						$type = [ 'list_of' => $this->get_query_type( $name, $attribute['query'], $prefix ) ];
+						$type = [ 'list_of' => $this->register_inner_object_type( $name, $attribute['query'], $prefix ) ];
 					} elseif ( isset( $attribute['items'] ) ) {
 						$of_type = $this->get_attribute_type( $name, $attribute['items'], $prefix );
 
@@ -230,16 +230,15 @@ class Block {
 	}
 
 	/**
-	 * Returns the type of the block query attribute
+	 * Dynamically creates and registers a GraphQL object type for queries or typed object attributes.
 	 *
-	 * @param string $name The block name
-	 * @param array  $query The block query config
-	 * @param string $prefix The current prefix string to use for registering the new query attribute type
+	 * @param string $name The block name.
+	 * @param array  $config The block config.
+	 * @param string $prefix The current prefix string to use for registering the new attribute type.
 	 */
-	private function get_query_type( string $name, array $query, string $prefix ): string {
-		$type = $prefix . ucfirst( $name );
-
-		$fields = $this->create_attributes_fields( $query, $type );
+	private function register_inner_object_type( string $name, array $config, string $prefix ): string {
+		$type   = $prefix . ucfirst( $name );
+		$fields = $this->create_attributes_fields( $config, $type );
 
 		register_graphql_object_type(
 			$type,

--- a/includes/Blocks/Block.php
+++ b/includes/Blocks/Block.php
@@ -54,7 +54,8 @@ class Block {
 	protected ?array $additional_block_attributes;
 
 	/**
-	 * A filtered array of block object attributes that are typed.
+	 * A filterable array of block object attributes that are typed.
+	 * The keys could be the object attribute names of the block and the value is an associative array where the key is the property name and the value is the type.
 	 *
 	 * @var array<string, array<string, "array"|"boolean"|"number"|"integer"|"object"|"rich-text"|"string">>
 	 */

--- a/includes/Blocks/Block.php
+++ b/includes/Blocks/Block.php
@@ -153,18 +153,7 @@ class Block {
 				$type = 'Int';
 				break;
 			case 'array':
-				// Process attributes query.
-				if ( isset( $attribute['query'] ) ) {
-					$type = [ 'list_of' => $this->register_inner_object_type( $name, $attribute['query'], $prefix ) ];
-					break;
-				}
-
-				// Process scalar array or list of items.
-				$of_type = null;
-				if ( isset( $attribute['items'] ) ) {
-					$of_type = $this->get_attribute_type( $name, $attribute['items'], $prefix );
-				}
-				$type = null !== $of_type ? [ 'list_of' => $of_type ] : Scalar::get_block_attributes_array_type_name();
+				$type = $this->process_array_attributes( $name, $attribute, $prefix );
 				break;
 			case 'object':
 				$type = Scalar::get_block_attributes_object_type_name();
@@ -180,6 +169,28 @@ class Block {
 		}
 
 		return $type;
+	}
+
+	/**
+	 * Processes the array attributes as query, list of items or scalar array.
+	 *
+	 * @param string              $name The block name
+	 * @param array<string,mixed> $attribute The block attribute config
+	 * @param string              $prefix Current prefix string to use for the get_query_type
+	 *
+	 * @return array|string
+	 */
+	private function process_array_attributes( $name, $attribute, $prefix ) {
+		if ( isset( $attribute['query'] ) ) {
+			return [ 'list_of' => $this->register_inner_object_type( $name, $attribute['query'], $prefix ) ];
+		}
+
+		$of_type = null;
+		if ( isset( $attribute['items'] ) ) {
+			$of_type = $this->get_attribute_type( $name, $attribute['items'], $prefix );
+		}
+
+		return null !== $of_type ? [ 'list_of' => $of_type ] : Scalar::get_block_attributes_array_type_name();
 	}
 
 	/**

--- a/tests/unit/BlockTest.php
+++ b/tests/unit/BlockTest.php
@@ -1,0 +1,150 @@
+<?php
+
+namespace WPGraphQL\ContentBlocks\Unit;
+
+use Mockery;
+use WPGraphQL\ContentBlocks\Blocks\Block;
+use WPGraphQL\ContentBlocks\Type\Scalar\Scalar;
+use WPGraphQL\ContentBlocks\Registry\Registry;
+use WP_Block_Type;
+use WP_Block_Type_Registry;
+use WPGraphQL;
+
+class BlockTest extends PluginTestCase {
+	protected $block;
+
+	public function setUp(): void {
+		parent::setUp();
+
+		// Ensure WP_Block_Type mock has a valid name.
+		$blockMock = Mockery::mock(WP_Block_Type::class);
+		$blockMock->name = 'test-block';  // Prevent null argument issue
+		$blockMock->attributes = [];
+
+		// Retrieve real instances required for Registry.
+		$typeRegistry = WPGraphQL::get_type_registry();
+		$blockTypeRegistry = WP_Block_Type_Registry::get_instance();
+
+		// Create an instance of Registry with dependencies.
+		$registry = new Registry($typeRegistry, $blockTypeRegistry);
+
+		// Create an instance of Block with the real dependencies.
+		$this->block = new Block($blockMock, $registry);
+	}
+
+	/**
+	 * Access private method get_attribute_type using reflection.
+	 */
+	private function invokeGetAttributeType($name, $attribute, $prefix) {
+		$method = new \ReflectionMethod($this->block, 'get_attribute_type');
+		$method->setAccessible(true);
+		return $method->invoke($this->block, $name, $attribute, $prefix);
+	}
+
+	public function testStringType() {
+		$attribute = ['type' => 'string'];
+		$this->assertEquals('String', $this->invokeGetAttributeType('block_name', $attribute, 'prefix'));
+	}
+
+	public function testBooleanType() {
+		$attribute = ['type' => 'boolean'];
+		$this->assertEquals('Boolean', $this->invokeGetAttributeType('block_name', $attribute, 'prefix'));
+	}
+
+	public function testFloatType() {
+		$attribute = ['type' => 'number'];
+		$this->assertEquals('Float', $this->invokeGetAttributeType('block_name', $attribute, 'prefix'));
+	}
+
+	public function testIntType() {
+		$attribute = ['type' => 'integer'];
+		$this->assertEquals('Int', $this->invokeGetAttributeType('block_name', $attribute, 'prefix'));
+	}
+
+	public function testArrayTypeWithoutQuery() {
+		$expectedArrayType = Scalar::get_block_attributes_array_type_name();
+
+		$attribute = ['type' => 'array'];
+		$this->assertEquals(
+			$expectedArrayType,
+			$this->invokeGetAttributeType('block_name', $attribute, 'prefix')
+		);
+	}
+
+	public function testArrayTypeWithQuery() {
+		$attribute = [
+			'type' => 'array',
+			'query' => [
+				'key' => [
+					'type' => 'string',
+				],
+			],
+		];
+
+		$result = $this->invokeGetAttributeType('block_name', $attribute, 'prefix');
+
+		$this->assertIsArray($result);
+		$this->assertArrayHasKey('list_of', $result);
+		$this->assertIsString($result['list_of']); // Expecting a generated GraphQL type name
+	}
+
+
+	public function testObjectType() {
+		// Call the real method instead of mocking
+		$expectedObjectType = Scalar::get_block_attributes_object_type_name();
+
+		$this->assertEquals(
+			$expectedObjectType,
+			$this->invokeGetAttributeType('block_name', ['type' => 'object'], 'prefix')
+		);
+	}
+
+	public function testWithDefaultValue() {
+		$attribute = ['type' => 'string', 'default' => 'test_value'];
+		$this->assertEquals(['non_null' => 'String'], $this->invokeGetAttributeType('block_name', $attribute, 'prefix'));
+	}
+
+	public function testArrayTypeWithItems() {
+		$attribute = [
+			'type' => 'array',
+			'items' => ['type' => 'integer']
+		];
+
+		$result = $this->invokeGetAttributeType('block_name', $attribute, 'prefix');
+
+		$this->assertIsArray($result);
+		$this->assertArrayHasKey('list_of', $result);
+		$this->assertEquals('Int', $result['list_of']); // Should be a list of integers
+	}
+
+	public function testAttributeWithSourceKey() {
+		$attribute = ['source' => 'meta'];
+
+		$this->assertEquals('String', $this->invokeGetAttributeType('block_name', $attribute, 'prefix'));
+	}
+
+	public function testUnknownOrMissingType() {
+		$attribute = []; // No 'type' key
+
+		$this->assertNull($this->invokeGetAttributeType('block_name', $attribute, 'prefix'));
+	}
+
+	public function testDefaultValuesForAllTypes() {
+		$cases = [
+			['type' => 'string', 'default' => 'text', 'expected' => ['non_null' => 'String']],
+			['type' => 'boolean', 'default' => true, 'expected' => ['non_null' => 'Boolean']],
+			['type' => 'number', 'default' => 3.14, 'expected' => ['non_null' => 'Float']],
+			['type' => 'integer', 'default' => 42, 'expected' => ['non_null' => 'Int']],
+			['type' => 'array', 'default' => [1, 2, 3], 'expected' => ['non_null' => Scalar::get_block_attributes_array_type_name()]],
+		];
+
+		foreach ($cases as $case) {
+			$this->assertEquals($case['expected'], $this->invokeGetAttributeType('block_name', $case, 'prefix'));
+		}
+	}
+
+	public function tearDown(): void {
+		Mockery::close();
+		parent::tearDown();
+	}
+}


### PR DESCRIPTION
### Description

Related Issue: #222 

This PR introduces _refactoring_ of the `get_attribute_type` method, _new functionality for creating typed attribute objects_ by specifying either in child class or via WP filter.

The previous related PR is [here](https://github.com/wpengine/wp-graphql-content-blocks/pull/336). Comparing with the previous one the current approach is not based on the `block.json` but on the `typed_object_attributes` protected property and WP filter.

---

## Querying Object-Type Block Attributes in WPGraphQL

### Overview
With this update, you can now query object-type block attributes with each property individually, provided that the **typed structure** is defined in the class `typed_object_attributes` property or through a **WordPress filter**.

### How It Works
The `typed_object_attributes` is a **filterable** array that defines the expected **typed structure** for object-type block attributes.

- The **keys** in `typed_object_attributes` correspond to **object attribute names** in the block.
- Each value is an **associative array**, where:
    - The key represents the **property name** inside the object.
    - The value defines the **WPGraphQL type** (e.g., `string`, `integer`, `object`, etc.).
- If a block attribute has a specified **typed structure**, only the properties listed within it will be processed.

### Defining Typed Object Attributes
Typed object attributes can be **defined in two ways**:

#### 1. In a Child Class (`typed_object_attributes` property)
Developers can extend the `Block` class and specify **typed properties** directly:

```php
class CustomMovieBlock extends Block {
	/**
	 * {@inheritDoc}
	 *
	 * @var array<string, array<string, "array"|"boolean"|"number"|"integer"|"object"|"rich-text"|"string">>
	 */
	protected array $typed_object_attributes = [
		'film' => [
			'id'         => 'integer',
			'title'      => 'string',
			'director'   => 'string',
			'soundtrack' => 'object',
		],
		'soundtrack' => [
			'title'  => 'string',
			'artist' => 'string'
		],
	];
}
```

#### 2. Via WordPress Filter
You can also define **typed structures dynamically** using a WordPress filter.

```php
add_filter(
    'wpgraphql_content_blocks_object_typing_my-custom-plugin_movie-block',
    function () {
        return [
            'film'       => [
                'id'         => 'integer',
                'title'      => 'string',
                'director'   => 'string',
                'soundtrack' => 'object',
            ],
            'soundtrack' => [
                'title'  => 'string',
                'artist' => 'string'
            ],
        ];
    }
);
```

### Filter Naming Convention
To apply custom typing via a filter, use the following format:

```
wpgraphql_content_blocks_object_typing_{block-name}
```
- Replace `/` in the block name with `-`.
- Example:
    - **Block name**: `my-custom-plugin/movie-block`
    - **Filter name**: `wpgraphql_content_blocks_object_typing_my-custom-plugin_movie-block`

### Example:


#### Example `block.json` Definition
If the block has attributes defined as **objects**, like this:

```json
"attributes": {
    "film": {
      "type": "object",
      "default": {
        "id": 1,
        "title": "The Matrix",
        "director": "Director Name"
      }
    },
    "soundtrack": {
      "type": "object",
      "default": {
        "title": "The Matrix Revolutions...",
        "artist": "Artist Name"
      }
    }
}
```
This means:
- The `film` attribute contains `id`, `title`, `director`.
- The `soundtrack` attribute contains `title` and `artist`.

### WPGraphQL Query Example
Once the typed object attributes are **defined**, you can query them **individually** in WPGraphQL.

```graphql
fragment Movie on MyCustomPluginMovieBlock {
    attributes {
        film {
            id
            title
            director
            soundtrack {
                title
            }
        }
        soundtrack {
            title
            artist
        }
    }
}

query GetAllPostsWhichSupportBlockEditor {
    posts {
        edges {
            node {
                editorBlocks {
                    __typename
                    name
                    ...Movie
                }
            }
        }
    }
}
```
---

