### PR TITLE
feat: Adds terms querying functionality for the CorePostTerms Block.

### DIFF
--- a/.changeset/calm-socks-battle.md
+++ b/.changeset/calm-socks-battle.md
@@ -1,0 +1,30 @@
+---
+"@wpengine/wp-graphql-content-blocks": minor
+---
+
+Adds support for resolving and returning related term items within the `terms` field of the CorePostTerms block.
+Adds support for resolving and returning the `prefix`, `suffix` and `term` items within the correspondent fields of the CorePostTerms block.
+
+```graphql
+query TestPostTerms($uri: String! = "test-terms") {
+    nodeByUri(uri: $uri) {
+        id
+        uri
+        ... on NodeWithPostEditorBlocks {
+            editorBlocks {
+                __typename
+                ... on CorePostTerms {
+                    prefix
+                    suffix
+                    term
+                    terms {
+                        __typename
+                        name
+                        id
+                    }
+                }
+            }
+        }
+    }
+}
+```

--- a/.changeset/calm-socks-battle.md
+++ b/.changeset/calm-socks-battle.md
@@ -2,7 +2,7 @@
 "@wpengine/wp-graphql-content-blocks": minor
 ---
 
-Adds support for resolving and returning related term items within the `terms` field of the CorePostTerms block.
+Adds support for resolving and returning related term items as a `terms` connection for the CorePostTerms block.
 Adds support for resolving and returning the `prefix`, `suffix` and `term` items within the correspondent fields of the CorePostTerms block.
 
 ```graphql

--- a/.changeset/calm-socks-battle.md
+++ b/.changeset/calm-socks-battle.md
@@ -2,8 +2,8 @@
 "@wpengine/wp-graphql-content-blocks": minor
 ---
 
-Adds support for resolving and returning related term items as a `terms` connection for the CorePostTerms block.
-Adds support for resolving and returning the `prefix`, `suffix` and `term` items within the correspondent fields of the CorePostTerms block.
+Adds support for resolving and returning related term items as a `terms` connection for the CorePostTerms block along with `taxonomy` connection.
+Adds support for resolving and returning the `prefix` and `suffix` items within the correspondent fields of the CorePostTerms block.
 
 ```graphql
 query TestPostTerms($uri: String! = "test-terms") {
@@ -16,11 +16,21 @@ query TestPostTerms($uri: String! = "test-terms") {
                 ... on CorePostTerms {
                     prefix
                     suffix
-                    term
+                    taxonomy {
+                        __typename
+                        node {
+                            __typename
+                            id
+                            name
+                        }
+                    }
                     terms {
                         __typename
-                        name
-                        id
+                        nodes {
+                            __typename
+                            id
+                            name
+                        }
                     }
                 }
             }

--- a/includes/Blocks/CorePostTerms.php
+++ b/includes/Blocks/CorePostTerms.php
@@ -1,0 +1,61 @@
+<?php
+/**
+ * Core Post Terms Block
+ *
+ * @package WPGraphQL\ContentBlocks\Blocks
+ */
+
+namespace WPGraphQL\ContentBlocks\Blocks;
+
+use WPGraphQL\ContentBlocks\Registry\Registry;
+use WPGraphQL\Model\Term;
+use WP_Block_Type;
+
+/**
+ * Class CorePostTerms.
+ */
+class CorePostTerms extends Block {
+	/**
+	 * {@inheritDoc}
+	 */
+	public function __construct( WP_Block_Type $block, Registry $block_registry ) {
+		parent::__construct( $block, $block_registry );
+
+		$this->register_list_of_terms_field();
+	}
+
+	/**
+	 * Registers a list of terms field for the block.
+	 *
+	 * @return void
+	 * @throws \Exception
+	 */
+	protected function register_list_of_terms_field() {
+		register_graphql_field(
+			$this->type_name,
+			'terms',
+			[
+				'type'        => [ 'list_of' => 'TermNode' ],
+				'description' => __( 'The terms associated with the post.', 'wp-graphql-content-blocks' ),
+				'resolve'     => static function ( $block ) {
+					$term = $block['attrs']['term'] ?? null;
+					if ( empty( $term ) ) {
+						return null;
+					}
+
+					$id = get_the_ID();
+					if ( ! $id ) {
+						return null;
+					}
+
+					$terms = get_the_terms( $id, $term );
+					if ( empty( $terms ) || is_wp_error( $terms ) ) {
+						return null;
+					}
+
+					return array_map( static fn ( $term ) => new Term( $term ), $terms );
+				},
+			]
+		);
+	}
+}

--- a/includes/Blocks/CorePostTerms.php
+++ b/includes/Blocks/CorePostTerms.php
@@ -31,7 +31,7 @@ class CorePostTerms extends Block {
 			]
 		);
 
-		$this->register_list_of_terms_field();
+		$this->register_list_of_terms_connection();
 	}
 
 	/**
@@ -58,7 +58,7 @@ class CorePostTerms extends Block {
 	 * @return void
 	 * @throws \Exception
 	 */
-	protected function register_list_of_terms_field() {
+	protected function register_list_of_terms_connection() {
 		register_graphql_connection(
 			[
 				'fromType'      => $this->type_name,

--- a/includes/Blocks/CorePostTerms.php
+++ b/includes/Blocks/CorePostTerms.php
@@ -17,48 +17,39 @@ use WP_Block_Type;
  */
 class CorePostTerms extends Block {
 	/**
-	 * String fields for the block.
-	 */
-	public const STRING_FIELDS = [ 'prefix', 'suffix', 'term' ];
-
-	/**
 	 * {@inheritDoc}
 	 */
 	public function __construct( WP_Block_Type $block, Registry $block_registry ) {
 		parent::__construct( $block, $block_registry );
 
-		foreach ( self::STRING_FIELDS as $field ) {
-			$this->register_string_field( $field );
-		}
+		register_graphql_fields(
+			$this->type_name,
+			[
+				'prefix' => $this->get_string_field_config( 'prefix' ),
+				'suffix' => $this->get_string_field_config( 'suffix' ),
+				'term'   => $this->get_string_field_config( 'term' ),
+			]
+		);
 
 		$this->register_list_of_terms_field();
 	}
 
 	/**
-	 * Registers a string field for the block.
+	 * Gets a string field for the block.
 	 *
 	 * @param string $name The name of the field.
-	 *
-	 * @return void
-	 * @throws \Exception
 	 */
-	protected function register_string_field( $name ) {
-		register_graphql_field(
-			$this->type_name,
-			$name,
-			[
-				'type'        => 'String',
-				'description' => sprintf(
-					// translators: %1$s is the field name, %2$s is the block type name.
-					__( '%1$s of the "%2$s" Block Type', 'wp-graphql-content-blocks' ),
-					ucfirst( $name ),
-					$this->type_name
-				),
-				'resolve'     => static function ( $block ) use ( $name ) {
-					return isset( $block['attrs'][ $name ] ) ? (string) $block['attrs'][ $name ] : null;
-				},
-			]
-		);
+	private function get_string_field_config( string $name ): array {
+		return [
+			'type'        => 'String',
+			'description' => sprintf(
+				// translators: %1$s is the field name, %2$s is the block type name.
+				__( '%1$s of the "%2$s" Block Type', 'wp-graphql-content-blocks' ),
+				ucfirst( $name ),
+				$this->type_name
+			),
+			'resolve'     => static fn ( $block ) => isset( $block['attrs'][ $name ] ) ? (string) $block['attrs'][ $name ] : null,
+		];
 	}
 
 	/**

--- a/includes/Blocks/CorePostTerms.php
+++ b/includes/Blocks/CorePostTerms.php
@@ -54,7 +54,7 @@ class CorePostTerms extends Block {
 					$this->type_name
 				),
 				'resolve'     => static function ( $block ) use ( $name ) {
-					return isset($block['attrs'][$name]) ? (string) $block['attrs'][$name] : null;
+					return isset( $block['attrs'][ $name ] ) ? (string) $block['attrs'][ $name ] : null;
 				},
 			]
 		);

--- a/includes/Blocks/CorePostTerms.php
+++ b/includes/Blocks/CorePostTerms.php
@@ -34,20 +34,15 @@ class CorePostTerms extends Block {
 		register_graphql_fields(
 			$this->type_name,
 			[
-				'prefix'       => [
+				'prefix' => [
 					'type'        => 'String',
 					'description' => __( 'Prefix to display before the post terms', 'wp-graphql-content-blocks' ),
 					'resolve'     => static fn ( $block ) => isset( $block['attrs']['prefix'] ) ? (string) $block['attrs']['prefix'] : null,
 				],
-				'suffix'       => [
+				'suffix' => [
 					'type'        => 'String',
 					'description' => __( 'Suffix to display after the post terms', 'wp-graphql-content-blocks' ),
 					'resolve'     => static fn ( $block ) => isset( $block['attrs']['suffix'] ) ? (string) $block['attrs']['suffix'] : null,
-				],
-				'taxonomySlug' => [
-					'type'        => 'String',
-					'description' => __( 'The taxonomy slug to display terms from', 'wp-graphql-content-blocks' ),
-					'resolve'     => static fn ( $block ) => isset( $block['attrs']['term'] ) ? (string) $block['attrs']['term'] : null,
 				],
 			]
 		);

--- a/includes/Blocks/CorePostTerms.php
+++ b/includes/Blocks/CorePostTerms.php
@@ -16,12 +16,48 @@ use WP_Block_Type;
  */
 class CorePostTerms extends Block {
 	/**
+	 * String fields for the block.
+	 */
+	public const STRING_FIELDS = [ 'prefix', 'suffix', 'term' ];
+
+	/**
 	 * {@inheritDoc}
 	 */
 	public function __construct( WP_Block_Type $block, Registry $block_registry ) {
 		parent::__construct( $block, $block_registry );
 
+		foreach ( self::STRING_FIELDS as $field ) {
+			$this->register_string_field( $field );
+		}
+
 		$this->register_list_of_terms_field();
+	}
+
+	/**
+	 * Registers a string field for the block.
+	 *
+	 * @param string $name The name of the field.
+	 *
+	 * @return void
+	 * @throws \Exception
+	 */
+	protected function register_string_field( $name ) {
+		register_graphql_field(
+			$this->type_name,
+			$name,
+			[
+				'type'        => 'String',
+				'description' => sprintf(
+					// translators: %1$s is the field name, %2$s is the block type name.
+					__( '%1$s of the "%2$s" Block Type', 'wp-graphql-content-blocks' ),
+					ucfirst( $name ),
+					$this->type_name
+				),
+				'resolve'     => static function ( $block ) use ( $name ) {
+					return isset($block['attrs'][$name]) ? (string) $block['attrs'][$name] : null;
+				},
+			]
+		);
 	}
 
 	/**

--- a/tests/unit/CorePostTermsTest.php
+++ b/tests/unit/CorePostTermsTest.php
@@ -1,0 +1,99 @@
+<?php
+
+namespace WPGraphQL\ContentBlocks\Unit;
+
+final class CorePostTermsTest extends PluginTestCase {
+
+	/**
+	 * The ID of the post created for the test.
+	 *
+	 * @var int
+	 */
+	public $post_id;
+
+	public function setUp(): void {
+		parent::setUp();
+
+		$this->post_id = wp_insert_post(
+			[
+				'post_title'   => 'Test Post',
+				'post_content' => '',
+				'post_status'  => 'publish',
+			]
+		);
+
+		\WPGraphQL::clear_schema();
+	}
+
+	public function tearDown(): void {
+		wp_delete_post($this->post_id, true);
+		\WPGraphQL::clear_schema();
+
+		parent::tearDown();
+	}
+
+	/**
+	 * Get the GraphQL query for the CorePostTerms block.
+	 */
+	public function query(): string {
+		return '
+			query TestPostTerms($id: ID!) {
+				post(id: $id, idType: DATABASE_ID) {
+					databaseId
+					editorBlocks {
+						__typename
+						... on CorePostTerms {
+							prefix
+							suffix
+							term
+							terms {
+								__typename
+								nodes {
+									id
+									name
+								}
+							}
+						}
+					}
+				}
+			}
+		';
+	}
+
+	/**
+	 * Test that the CorePostTerms block retrieves attributes and terms correctly.
+	 */
+	public function test_retrieve_core_post_terms(): void {
+		$block_content = '<!-- wp:post-terms {"prefix":"Before","suffix":"After","term":"category"} /-->';
+
+		wp_update_post(
+			[
+				'ID'           => $this->post_id,
+				'post_content' => $block_content,
+			]
+		);
+
+		$variables = [ 'id' => $this->post_id ];
+		$query = $this->query();
+		$actual = graphql(compact('query', 'variables'));
+
+		$node = $actual['data']['post'];
+
+		$this->assertEquals($this->post_id, $node['databaseId']);
+		$this->assertArrayHasKey('editorBlocks', $node);
+		$this->assertCount(1, $node['editorBlocks']);
+
+		$block = $node['editorBlocks'][0];
+
+		$this->assertEquals('CorePostTerms', $block['__typename']);
+		$this->assertEquals('Before', $block['prefix']);
+		$this->assertEquals('After', $block['suffix']);
+		$this->assertEquals('category', $block['term']);
+
+		$this->assertArrayHasKey('terms', $block);
+		$this->assertArrayHasKey('nodes', $block['terms']);
+		$this->assertIsArray($block['terms']['nodes']);
+
+		$this->assertEquals('CorePostTermsToTermNodeConnection', $block['terms']['__typename']);
+	}
+}

--- a/tests/unit/CorePostTermsTest.php
+++ b/tests/unit/CorePostTermsTest.php
@@ -45,7 +45,7 @@ final class CorePostTermsTest extends PluginTestCase {
 						... on CorePostTerms {
 							prefix
 							suffix
-							term
+							taxonomySlug
 							terms {
 								__typename
 								nodes {
@@ -88,7 +88,7 @@ final class CorePostTermsTest extends PluginTestCase {
 		$this->assertEquals('CorePostTerms', $block['__typename']);
 		$this->assertEquals('Before', $block['prefix']);
 		$this->assertEquals('After', $block['suffix']);
-		$this->assertEquals('category', $block['term']);
+		$this->assertEquals('category', $block['taxonomySlug']);
 
 		$this->assertArrayHasKey('terms', $block);
 		$this->assertArrayHasKey('nodes', $block['terms']);


### PR DESCRIPTION
### Description

Related issue: #180 

- Adds terms querying functionality for the CorePostTerms Block.
New `terms` ~~field~~ **connection** registered. ~~Resolves as a list_of TermNode~~
New `taxonomy` connection registered.

- Additionally adds support for the `prefix` and `suffix` items with correspondent newly registered string fields.

```graphql
query TestPostTerms($uri: String! = "test-terms") {
  nodeByUri(uri: $uri) {
    id
    uri
    ... on NodeWithPostEditorBlocks {
      editorBlocks {
        __typename
        ... on CorePostTerms {
          prefix
          suffix
          taxonomy {
            __typename
            node {
              __typename
              id
              name
            }
          }
          terms {
            __typename
            nodes {
              __typename
              id
              name
            }
          }
        }
      }
    }
  }
}
```