### PR TITLE
Fix revert coreimage block width type

### DIFF
--- a/.changeset/many-garlics-divide.md
+++ b/.changeset/many-garlics-divide.md
@@ -1,5 +1,7 @@
 ---
-"@wpengine/wp-graphql-content-blocks": patch
+"@wpengine/wp-graphql-content-blocks": major
 ---
 
 Fix: reverts CoreImage block width type introduced at this [PR](https://github.com/wpengine/wp-graphql-content-blocks/pull/130)
+
+**NOTE**: This change is only impactful for users running WordPress versions earlier than v6.3.2.

--- a/.changeset/many-garlics-divide.md
+++ b/.changeset/many-garlics-divide.md
@@ -1,0 +1,5 @@
+---
+"@wpengine/wp-graphql-content-blocks": patch
+---
+
+Fix: reverts CoreImage block width type introduced at this [PR](https://github.com/wpengine/wp-graphql-content-blocks/pull)

--- a/.changeset/many-garlics-divide.md
+++ b/.changeset/many-garlics-divide.md
@@ -2,4 +2,4 @@
 "@wpengine/wp-graphql-content-blocks": patch
 ---
 
-Fix: reverts CoreImage block width type introduced at this [PR](https://github.com/wpengine/wp-graphql-content-blocks/pull)
+Fix: reverts CoreImage block width type introduced at this [PR](https://github.com/wpengine/wp-graphql-content-blocks/pull/130)

--- a/includes/Blocks/CoreImage.php
+++ b/includes/Blocks/CoreImage.php
@@ -42,6 +42,7 @@ class CoreImage extends Block {
 	 */
 	public function __construct( WP_Block_Type $block, Registry $block_registry ) {
 		parent::__construct( $block, $block_registry );
+		
 		register_graphql_field(
 			$this->type_name,
 			'mediaDetails',

--- a/includes/Blocks/CoreImage.php
+++ b/includes/Blocks/CoreImage.php
@@ -42,7 +42,7 @@ class CoreImage extends Block {
 	 */
 	public function __construct( WP_Block_Type $block, Registry $block_registry ) {
 		parent::__construct( $block, $block_registry );
-		
+
 		register_graphql_field(
 			$this->type_name,
 			'mediaDetails',

--- a/includes/Blocks/CoreImage.php
+++ b/includes/Blocks/CoreImage.php
@@ -32,7 +32,6 @@ class CoreImage extends Block {
 			'source'    => 'attribute',
 			'attribute' => 'src',
 		],
-		'width'        => [ 'type' => 'string' ],
 	];
 
 	/**
@@ -43,7 +42,6 @@ class CoreImage extends Block {
 	 */
 	public function __construct( WP_Block_Type $block, Registry $block_registry ) {
 		parent::__construct( $block, $block_registry );
-
 		register_graphql_field(
 			$this->type_name,
 			'mediaDetails',


### PR DESCRIPTION
Reverts https://github.com/wpengine/wp-graphql-content-blocks/pull/130