### PR TITLE
Replace core/block with core/synced-pattern (Changes GraphQL response structure)

### DIFF
--- a/.changeset/cold-doors-give.md
+++ b/.changeset/cold-doors-give.md
@@ -1,0 +1,68 @@
+---
+"@wpengine/wp-graphql-content-blocks": major
+---
+
+Replaced core/block with core/synced-pattern for reusable blocks, aligning with WP 6.3's synced patterns. 
+
+**🚨Breaking change🚨** for WordPress versions < 6.3, as core/synced-pattern does not exist in earlier versions.
+
+Query:
+```
+{
+  posts {
+    nodes {
+      editorBlocks {
+        name
+        clientId
+        parentClientId
+        ... on CoreSyncedPattern {
+          attributes {
+            slug
+          }
+          name
+          innerBlocks {
+            name
+            clientId
+            parentClientId
+          }
+        }
+      }
+    }
+  }
+}
+```
+Response:
+```
+{
+  "data": {
+    "posts": {
+      "nodes": [
+        {
+          "editorBlocks": [
+            {
+              "name": "core/synced-pattern",
+              "clientId": "67b317909b801",
+              "parentClientId": null,
+              "attributes": {
+                "slug": "my-synced-pattern"
+              },
+              "innerBlocks": [
+                {
+                  "name": "core/group",
+                  "clientId": "67b317909b89a",
+                  "parentClientId": null
+                }
+              ]
+            },
+            {
+              "name": "core/group",
+              "clientId": "67b317909b89a",
+              "parentClientId": "67b317909b801"
+            }
+            ]
+        }
+      ]
+    }
+  }
+}
+```

--- a/.changeset/cold-doors-give.md
+++ b/.changeset/cold-doors-give.md
@@ -4,7 +4,7 @@
 
 Replaced core/block with core/synced-pattern for reusable blocks, aligning with WP 6.3's synced patterns. 
 
-**🚨Breaking change🚨** for WordPress versions < 6.3, as core/synced-pattern does not exist in earlier versions.
+**🚨Breaking change🚨** This update does not break functionality for WP < 6.3, but it alters the GraphQL response structure.
 
 Query:
 ```

--- a/includes/Data/ContentBlocksResolver.php
+++ b/includes/Data/ContentBlocksResolver.php
@@ -170,7 +170,8 @@ final class ContentBlocksResolver {
 			return false;
 		}
 
-		if ( isset( $block['blockName'] ) && 'core/synced-pattern' === $block['blockName'] ) {
+		if ( isset( $block['attrs']['ref'] ) ) {
+			// If 'ref' exists, it's likely a synced pattern, so we don't consider it empty.
 			return false;
 		}
 

--- a/includes/Registry/Registry.php
+++ b/includes/Registry/Registry.php
@@ -276,7 +276,7 @@ final class Registry {
 					'name'            => $block_name,
 					'title'           => __( 'Synced Pattern', 'wp-graphql-content-blocks' ),
 					'icon'            => null,
-					'category'        => 'reusable',
+					'category'        => 'theme',
 					'attributes'      => [
 						'ref'  => [
 							'type' => 'number',

--- a/includes/Registry/Registry.php
+++ b/includes/Registry/Registry.php
@@ -68,6 +68,7 @@ final class Registry {
 		$this->register_interface_types();
 		$this->register_scalar_types();
 		$this->register_support_block_types();
+		$this->register_custom_block_types();
 		$this->register_block_types();
 	}
 
@@ -255,6 +256,41 @@ final class Registry {
 				register_graphql_interfaces_to_types( [ 'NodeWith' . Utils::format_type_name( $post_type->graphql_single_name ) . 'EditorBlocks' ], [ $type_name ] );
 			}
 		}//end foreach
+	}
+
+	/**
+	 * Registers custom block types.
+	 *
+	 * The 'core/synced-pattern' block is a reusable synced pattern block and
+	 * is not meant to appear in the block editor selection but is used
+	 * internally for resolving reusable content.
+	 */
+	protected function register_custom_block_types(): void {
+		$registry   = \WP_Block_Type_Registry::get_instance();
+		$block_name = 'core/synced-pattern';
+
+		if ( ! $registry->is_registered( $block_name ) ) {
+			$registry->register(
+				$block_name,
+				[
+					'name'            => $block_name,
+					'title'           => __( 'Synced Pattern', 'wp-graphql-content-blocks' ),
+					'icon'            => null,
+					'category'        => 'reusable',
+					'attributes'      => [
+						'ref'  => [
+							'type' => 'number',
+						],
+						'slug' => [
+							'type' => 'string',
+						],
+					],
+					'render_callback' => static function ( $attributes, $content ) {
+						return $content;
+					},
+				]
+			);
+		}
 	}
 
 	/**

--- a/tests/unit/ContentBlocksResolverTest.php
+++ b/tests/unit/ContentBlocksResolverTest.php
@@ -101,10 +101,16 @@ final class ContentBlocksResolverTest extends PluginTestCase {
 	public function test_resolve_content_blocks_resolves_reusable_blocks() {
 		$post_model = new Post( get_post( $this->reusable_post_id ) );
 		$actual     = $this->instance->resolve_content_blocks( $post_model, [ 'flat' => true ] );
+	
+		$this->assertNotEmpty( $actual );
+		$this->assertEquals( 'core/synced-pattern', $actual[0]['blockName'] );
+	
+		$this->assertArrayHasKey( 'attrs', $actual[0] );
+		$this->assertArrayHasKey( 'ref', $actual[0]['attrs'] );
+		$this->assertArrayHasKey( 'slug', $actual[0]['attrs'] );
 
-		// There should return only the non-empty blocks
-		$this->assertEquals( 3, count( $actual ) );
-		$this->assertEquals( 'core/columns', $actual[0]['blockName'] );
+		$this->assertEquals( 'core/columns', $actual[1]['blockName'] );
+		$this->assertCount( 4, $actual );
 	}
 
 	public function test_resolve_content_blocks_filters_empty_blocks() {


### PR DESCRIPTION
# Description:
* Replaced `core/block` with `core/synced-pattern`, based on WP 6.3's changes to reusable blocks
* This update does not break functionality for WP < 6.3, but it alters the GraphQL response structure.
* Updated test cases to reflect the new structure.

**Breaking Change Notice:**
For WP < 6.3: The plugin remains functional, but GraphQL responses now return core/synced-pattern instead of returning a list of innerBlocks of that pattern


Previously, the response directly returned the inner blocks of the reusable pattern directly, stripping all the information about the `core/block` type:

```json
[
    {
        "blockName": "core/columns",
        "attrs": {},
        "innerBlocks": [
            {
                "blockName": "core/column",
                "attrs": {},
                "innerBlocks": [
                    {
                        "blockName": "core/paragraph",
                        "attrs": {},
                        "innerHTML": "<p>Example paragraph in Column 1</p>"
                    }
                ]
            }
        ]
    }
]

```

Now, the reusable block is wrapped inside core/synced-pattern,
```json
[
    {
        "blockName": "core/synced-pattern",
        "attrs": {
            "ref": 9,
            "slug": "my-synced-pattern"
        },
        "innerBlocks": [
            {
                "blockName": "core/columns",
                "attrs": {},
                "innerBlocks": [
                    {
                        "blockName": "core/column",
                        "attrs": {},
                        "innerBlocks": [
                            {
                                "blockName": "core/paragraph",
                                "attrs": {},
                                "innerHTML": "<p>Example paragraph in Column 1</p>"
                            }
                        ]
                    }
                ]
            }
        ]
    }
]
```

# Reference 
#345 https://github.com/wpengine/wp-graphql-content-blocks/issues/345

# How to Test the Changes
1. Create a New Synced Pattern
Go to Appearance > Editor (or Design > Patterns in WP 6.3+).
Click Manage all patterns and then Add New Pattern.
Ensure "Synced" is enabled before saving.
2. Add the Synced Pattern to a Post
Create or edit a post.
Add a new block and select the synced pattern you just created.
Save the post.
3. Verify the GraphQL Response
Run the following GraphQL query to fetch the blocks in the post:

```graphql
{
  posts {
    nodes {
      editorBlocks {
        name
        clientId
        parentClientId
      }
    }
  }
}
```
Expected result:

The core/synced-pattern block is returned as the parent, with its inner blocks nested inside it. The parentClientId of the inner blocks should reference the core/synced-pattern block.
Example response:

```json
{
  "name": "core/synced-pattern",
  "clientId": "67b3247b727c4",
  "parentClientId": null
},
{
  "name": "core/group",
  "clientId": "67b3247b7285a",
  "parentClientId": "67b3247b727c4"
}
```
