### PR TITLE
bug: Fixes WP GraphQL fatal deactivation error

### DIFF
--- a/.changeset/wicked-vans-fly.md
+++ b/.changeset/wicked-vans-fly.md
@@ -1,0 +1,5 @@
+---
+"@wpengine/wp-graphql-content-blocks": patch
+---
+
+bug: Fixes fatal error when you de-activate WPGraphQL

--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
   "require": {
     "php": ">=7.4",
     "imangazaliev/didom": "^2.0",
-    "blakewilson/wp-enforce-semver": "^2.0"
+    "blakewilson/wp-enforce-semver": "^3.0"
   },
   "require-dev": {
     "brain/monkey": "^2.6",

--- a/composer.lock
+++ b/composer.lock
@@ -4,20 +4,20 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "e195db6610328483e6cc589d5f5cde33",
+    "content-hash": "9869bdd90f5a813011427a5af0592daa",
     "packages": [
         {
             "name": "blakewilson/wp-enforce-semver",
-            "version": "2.0.2",
+            "version": "3.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/blakewilson/wp-enforce-semver.git",
-                "reference": "f65b621d7534db802839b74104309269215ef8a3"
+                "reference": "2c524d2cd9dbfadc31b4eabfacae1e742928ff57"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/blakewilson/wp-enforce-semver/zipball/f65b621d7534db802839b74104309269215ef8a3",
-                "reference": "f65b621d7534db802839b74104309269215ef8a3",
+                "url": "https://api.github.com/repos/blakewilson/wp-enforce-semver/zipball/2c524d2cd9dbfadc31b4eabfacae1e742928ff57",
+                "reference": "2c524d2cd9dbfadc31b4eabfacae1e742928ff57",
                 "shasum": ""
             },
             "require": {
@@ -47,9 +47,9 @@
             "description": "A class to enforce SemVer in your WordPress plugins.",
             "support": {
                 "issues": "https://github.com/blakewilson/wp-enforce-semver/issues",
-                "source": "https://github.com/blakewilson/wp-enforce-semver/tree/2.0.2"
+                "source": "https://github.com/blakewilson/wp-enforce-semver/tree/3.0.1"
             },
-            "time": "2024-02-05T20:14:37+00:00"
+            "time": "2024-07-05T18:56:06+00:00"
         },
         {
             "name": "imangazaliev/didom",
@@ -4335,7 +4335,7 @@
     "platform": {
         "php": ">=7.4"
     },
-    "platform-dev": [],
+    "platform-dev": {},
     "platform-overrides": {
         "php": "7.4"
     },

--- a/wp-graphql-content-blocks.php
+++ b/wp-graphql-content-blocks.php
@@ -11,7 +11,7 @@
  * Version: 4.8.0
  * Requires PHP: 7.4
  * Requires at least: 5.7
- *
+ * Requires Plugins: wp-graphql
  * @package WPGraphQL\ContentBlocks
  */
 

--- a/wp-graphql-content-blocks.php
+++ b/wp-graphql-content-blocks.php
@@ -12,6 +12,8 @@
  * Requires PHP: 7.4
  * Requires at least: 5.7
  * Requires Plugins: wp-graphql
+ * WPGraphQL requires at least: 1.14.5
+ * WPGraphQL tested up to: 2.0.0
  * @package WPGraphQL\ContentBlocks
  */
 

--- a/wp-graphql-content-blocks.php
+++ b/wp-graphql-content-blocks.php
@@ -14,6 +14,7 @@
  * Requires Plugins: wp-graphql
  * WPGraphQL requires at least: 1.14.5
  * WPGraphQL tested up to: 2.0.0
+ *
  * @package WPGraphQL\ContentBlocks
  */
 


### PR DESCRIPTION
Solves #350 and #353 

# Overview

- Fixes a bug with WPGraphQL Content Blocks causing a fatal error when WPGraphQL is de-activated.  The plugin now requires WPGraphQL
- Added plugin info for WPGraphQL. Tested to 2.0 and requires at least 1.14.5 (same as composer lock file)

# Tests

Installed WPGraphQL 2.0 on WP 6.7.2 with Local

1. Couldn't enable WPGraphQL Content Blocks until WPGraphQL was enabled
2. WPGraphQL plugin couldn't be disabled when WPGraphQL Content Blocks was activated too


# Screenshots

<img width="1482" alt="Screenshot 2025-02-26 at 17 39 05" src="https://github.com/user-attachments/assets/a2b8a41a-cc81-45d8-966d-d3f27ea5e50b" />

<img width="1547" alt="Screenshot 2025-02-26 at 17 39 16" src="https://github.com/user-attachments/assets/3c466607-678a-4a50-ac2c-31f915f5abb6" />

<img width="1560" alt="Screenshot 2025-02-26 at 17 39 30" src="https://github.com/user-attachments/assets/55be8962-5e24-4d5d-8be0-77eaaea5c7ca" />




