### PR TITLE
bug: Fix semver fatal error

### DIFF
--- a/.changeset/modern-pigs-matter.md
+++ b/.changeset/modern-pigs-matter.md
@@ -1,0 +1,5 @@
+---
+"@wpengine/wp-graphql-content-blocks": patch
+---
+
+bug: Fixes fatal error on the Site Health page for the info tab. Caused by a naming of the wrong object key in the Semver package.

--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,8 @@
   "require": {
     "php": ">=7.4",
     "imangazaliev/didom": "^2.0",
-    "blakewilson/wp-enforce-semver": "^3.0"
+    "blakewilson/wp-enforce-semver": "^3.0",
+    "cweagans/composer-patches": "^1"
   },
   "require-dev": {
     "brain/monkey": "^2.6",
@@ -37,7 +38,8 @@
   "config": {
     "allow-plugins": {
       "dealerdirect/phpcodesniffer-composer-installer": true,
-      "phpstan/extension-installer": true
+      "phpstan/extension-installer": true,
+      "cweagans/composer-patches": true
     },
     "platform": {
       "php": "7.4"
@@ -57,6 +59,13 @@
   "autoload-dev": {
     "psr-4": {
         "WPGraphQL\\ContentBlocks\\Unit\\": "tests/unit/"
+    }
+  },
+  "extra": {
+    "patches": {
+      "blakewilson/wp-enforce-semver": {
+        "Fixes version key case": "patches/blakewilson-wp-enforce-semver/semver-object-key-version.patch"
+      }
     }
   }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "9869bdd90f5a813011427a5af0592daa",
+    "content-hash": "fcd099561ddf8f64d253a2ded87ed329",
     "packages": [
         {
             "name": "blakewilson/wp-enforce-semver",
@@ -50,6 +50,54 @@
                 "source": "https://github.com/blakewilson/wp-enforce-semver/tree/3.0.1"
             },
             "time": "2024-07-05T18:56:06+00:00"
+        },
+        {
+            "name": "cweagans/composer-patches",
+            "version": "1.7.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/cweagans/composer-patches.git",
+                "reference": "e190d4466fe2b103a55467dfa83fc2fecfcaf2db"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/cweagans/composer-patches/zipball/e190d4466fe2b103a55467dfa83fc2fecfcaf2db",
+                "reference": "e190d4466fe2b103a55467dfa83fc2fecfcaf2db",
+                "shasum": ""
+            },
+            "require": {
+                "composer-plugin-api": "^1.0 || ^2.0",
+                "php": ">=5.3.0"
+            },
+            "require-dev": {
+                "composer/composer": "~1.0 || ~2.0",
+                "phpunit/phpunit": "~4.6"
+            },
+            "type": "composer-plugin",
+            "extra": {
+                "class": "cweagans\\Composer\\Patches"
+            },
+            "autoload": {
+                "psr-4": {
+                    "cweagans\\Composer\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Cameron Eagans",
+                    "email": "me@cweagans.net"
+                }
+            ],
+            "description": "Provides a way to patch Composer packages.",
+            "support": {
+                "issues": "https://github.com/cweagans/composer-patches/issues",
+                "source": "https://github.com/cweagans/composer-patches/tree/1.7.3"
+            },
+            "time": "2022-12-20T22:53:13+00:00"
         },
         {
             "name": "imangazaliev/didom",

--- a/patches/blakewilson-wp-enforce-semver/semver-object-key-version.patch
+++ b/patches/blakewilson-wp-enforce-semver/semver-object-key-version.patch
@@ -1,0 +1,12 @@
+diff --git a/vendor/blakewilson/wp-enforce-semver/src/EnforceSemVer.php b/vendor/blakewilson/wp-enforce-semver/src/EnforceSemVer.php
+--- a/vendor/blakewilson/wp-enforce-semver/src/EnforceSemVer.php	
++++ b/vendor/blakewilson/wp-enforce-semver/src/EnforceSemVer.php	(date 1741188709127)
+@@ -63,7 +63,7 @@
+ 		 */
+ 		if (
+ 				$this->plugin_filename === $item->plugin &&
+-				$this->does_new_version_have_major_change( $item->new_version, $item->Version ) ) { // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
++				$this->does_new_version_have_major_change( $item->new_version, $item->version ) ) { // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
+ 			return false;
+ 		} else {
+ 			return $update;

--- a/patches/blakewilson-wp-enforce-semver/semver-object-key-version.patch
+++ b/patches/blakewilson-wp-enforce-semver/semver-object-key-version.patch
@@ -1,6 +1,6 @@
-diff --git a/vendor/blakewilson/wp-enforce-semver/src/EnforceSemVer.php b/vendor/blakewilson/wp-enforce-semver/src/EnforceSemVer.php
---- a/vendor/blakewilson/wp-enforce-semver/src/EnforceSemVer.php	
-+++ b/vendor/blakewilson/wp-enforce-semver/src/EnforceSemVer.php	(date 1741188709127)
+diff --git a/src/EnforceSemVer.php b/src/EnforceSemVer.php
+--- a/src/EnforceSemVer.php	
++++ b/src/EnforceSemVer.php	(date 1741188709127)
 @@ -63,7 +63,7 @@
  		 */
  		if (


### PR DESCRIPTION
This fixes a fatal error when you go to the Site Health info tab in WordPress. 

Currently used a composer patch as a short term fix.


# QA

## Site Health

1. Go to Tools -> Site Health
2. Click on the "info" tab

There shouldn't be a fatal error

<img width="1420" alt="Screenshot 2025-03-05 at 16 20 53" src="https://github.com/user-attachments/assets/3179c668-5df8-4f87-ada8-1d3ff3e1247c" />


## Plugin Page

1. Check that you cannot enable WPGraphQL Content Blocks without WPGraphQL enabled

<img width="1525" alt="Screenshot 2025-03-05 at 16 24 05" src="https://github.com/user-attachments/assets/9d7ab58b-df09-456b-a1e4-881445ffd8df" />

<img width="1551" alt="Screenshot 2025-03-05 at 16 24 44" src="https://github.com/user-attachments/assets/c6503852-fae2-454a-9d9f-e63fe53cc6a2" />


2. Check  that you cannot disable WPGraphQL when WPGraphQL Content Blocks is enabled

<img width="1543" alt="Screenshot 2025-03-05 at 16 25 55" src="https://github.com/user-attachments/assets/9f15e9cf-a13b-4da5-8e1d-6aa9f9a4eed9" />



