### PR TITLE
fix(deps): add missing webpack-dev-server override (unbreaks main)

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
   "overrides": {
     "serialize-javascript": "^7.0.5",
     "uuid": "^11.1.1",
+    "webpack-dev-server": "^5.2.4",
     "@typescript-eslint/typescript-estree": {
       "minimatch": "^9.0.7"
     },


### PR DESCRIPTION
## Summary

- `npm ci` on `main` is failing — PR #442 (1c3b6df) added the `webpack-dev-server@5.2.4` resolution to `package-lock.json` but left the corresponding entry **out** of the `overrides` block in `package.json`. The lockfile has `5.2.4` while package.json's natural tree (via `@wordpress/scripts`) wants `4.15.2`, with no override to bridge them.
- This breaks the `release.yml` workflow (failed run [26516976225](https://github.com/wpengine/wp-graphql-content-blocks/actions/runs/26516976225)) — without it, the changesets action can't install deps to refresh PR #403 or publish 4.8.5.
- Adding the missing `"webpack-dev-server": "^5.2.4"` line is sufficient; lockfile is already at the correct resolution and `npm install --package-lock-only` is a no-op.

## Test plan

- [x] `npm ci --dry-run` exits 0 locally with the patched `package.json`
- [x] `npm install --package-lock-only` makes no further changes to the lockfile
- [ ] CI green on this PR
- [ ] After merge: release.yml succeeds, PR #403 refreshes with the security changeset alongside WP 6.9 compat